### PR TITLE
Save the config

### DIFF
--- a/src/nanorc/__main__.py
+++ b/src/nanorc/__main__.py
@@ -76,11 +76,12 @@ def updateLogLevel(loglevel):
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--loglevel', type=click.Choice(loglevels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--timeout', type=int, default=60, help='Application commands timeout')
+@click.option('--cfg-outdir', type=click.Path(), default="./")
 
 @click.argument('cfg_dir', type=click.Path(exists=True))
 @click.pass_obj
 @click.pass_context
-def cli(ctx, obj, traceback, loglevel, timeout, cfg_dir):
+def cli(ctx, obj, traceback, loglevel, timeout, cfg_outdir, cfg_dir):
 
     obj.print_traceback = traceback
 
@@ -98,7 +99,7 @@ def cli(ctx, obj, traceback, loglevel, timeout, cfg_dir):
         updateLogLevel(loglevel)
 
     try:
-        rc = NanoRC(obj.console, cfg_dir, timeout)
+        rc = NanoRC(obj.console, cfg_dir, cfg_outdir, timeout)
     except Exception as e:
         logging.getLogger("cli").exception("Failed to build NanoRC")
         raise click.Abort()

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -2,11 +2,9 @@ import os.path
 import json
 import copy
 import socket
-from distutils.dir_util import copy_tree
 
 """Extract nested values from a JSON tree."""
 
-CFG_OUTDIR=os.path.expanduser("~/")
 
 def json_extract(obj, key):
     """Recursively fetch values from nested JSON."""
@@ -118,31 +116,15 @@ class ConfigManager:
         :param      data:  The data
         :type       data:  dict
 
-        :returns:   Complete parameter set and path of the saved config
-        :rtype:     tuple(dict, str)
+        :returns:   Complete parameter set.
+        :rtype:     dict
         """
         start = copy.deepcopy(self.start)
 
-        outdir = CFG_OUTDIR+"/RunConf_"+str(data["run"])
-        postfix = ""
-        counter = 1
-        while os.path.exists(outdir+postfix):
-            counter+=1
-            postfix = "_"+str(counter)
-
-        self.outdir = outdir+postfix+"/"
-        os.mkdir(self.outdir)
-        copy_tree(self.cfg_dir, self.outdir)
-
-        config = json_extract(start, "modules")
-        for c in config:
+        for c in json_extract(start, "modules"):
             for m in c:
                 m["data"].update(data)
-
-        f = open(self.outdir+"start_parsed.json", "w")
-        f.write(json.dumps(config, indent=2))
-        f.close()
-        return start,self.outdir
+        return start
 
     def runtime_resume(self, data: dict) -> dict:
         """
@@ -155,26 +137,13 @@ class ConfigManager:
         """
         resume = copy.deepcopy(self.resume)
 
-        postfix = ""
-        counter = 1
-        while os.path.exists(self.outdir+"resume_parsed"+postfix+".json"):
-            counter+=1
-            postfix = "_"+str(counter)
-
-        config = json_extract(resume, "modules")
-        for c in config:
+        for c in json_extract(resume, "modules"):
             for m in c:
                 m["data"].update(data)
-
-        file_name = self.outdir+"resume_parsed"+postfix+".json"
-        f = open(file_name, "w")
-        f.write(json.dumps(config, indent=2))
-        f.close()
         return resume
 
 
 if __name__ == "__main__":
-    import sys
     from os.path import dirname, join
     from rich.console import Console
     from rich.pretty import Pretty
@@ -182,7 +151,7 @@ if __name__ == "__main__":
 
     console = Console()
     try:
-        cfg = ConfigManager(sys.argv[1])
+        cfg = ConfigManager(join(dirname(__file__), "examples", "minidaqapp"))
     except Exception as e:
         console.print(Traceback())
 
@@ -206,10 +175,4 @@ if __name__ == "__main__":
     console.print(Pretty(cfg.stop_order))
 
     console.print("Start data V:runner:")
-    console.print(Pretty(cfg.runtime_start({"trigger_interval_ticks": "bb"}, 1001)))
-
-    console.print("Resume :runner:")
-    console.print(Pretty(cfg.runtime_resume({"trigger_interval_ticks": "bb"})))
-
-    console.print("Resume :runner:")
-    console.print(Pretty(cfg.runtime_resume({"trigger_interval_ticks": "cc"})))
+    console.print(Pretty(cfg.runtime_start({"aa": "bb"})))

--- a/src/nanorc/cfgsvr.py
+++ b/src/nanorc/cfgsvr.py
@@ -1,14 +1,15 @@
 import os.path
 import json
 import copy
+from .cfgmgr import ConfigManager
 from distutils.dir_util import copy_tree
 
 class ConfigSaver:
     """docstring for ConfigManager"""
 
-    def __init__(self, cfg_dir, cfg_outdir):
+    def __init__(self, cfgmgr:ConfigManager, cfg_outdir:str):
         super(ConfigSaver, self).__init__()
-        self.cfg_dir = cfg_dir
+        self.cfgmgr = cfgmgr
         self.outdir = cfg_outdir
 
     def _get_new_out_dir_name(self, run:int) -> str:
@@ -59,9 +60,8 @@ class ConfigSaver:
         :rtype:     str
         """
         self.thisrun_outdir = self._get_new_out_dir_name(run)
-        print(self.thisrun_outdir)
         os.makedirs(self.thisrun_outdir)
-        copy_tree(self.cfg_dir, self.thisrun_outdir)
+        copy_tree(self.cfgmgr.cfg_dir, self.thisrun_outdir)
 
         f = open(self.thisrun_outdir+"start_parsed.json", "w")
         f.write(json.dumps(data, indent=2))
@@ -97,7 +97,8 @@ if __name__ == "__main__":
     @click.argument('cfg_outdir', type=click.Path())
     @click.argument('run', type=int)
     def config_saver_test(cfg_dir, cfg_outdir, run):
-        instance = ConfigSaver(cfg_dir, cfg_outdir)
+        cfgmgr = ConfigManager(join(dirname(__file__), "examples", "minidaqapp"))
+        instance = ConfigSaver(cfgmgr, cfg_outdir)
         print(f"Save start data for run {run}")
         runtime_start_data = {
             "disable_data_storage": True,

--- a/src/nanorc/cfgsvr.py
+++ b/src/nanorc/cfgsvr.py
@@ -1,0 +1,114 @@
+import os.path
+import json
+import copy
+from distutils.dir_util import copy_tree
+
+class ConfigSaver:
+    """docstring for ConfigManager"""
+
+    def __init__(self, cfg_dir, cfg_outdir):
+        super(ConfigSaver, self).__init__()
+        self.cfg_dir = cfg_dir
+        self.outdir = cfg_outdir
+
+    def _get_new_out_dir_name(self, run:int) -> str:
+        """
+        Create a unique directory name for saving the configs in this run
+        :param      run :  run number
+        :type       run :  int
+
+        :returns:   Path for saving the config
+        :rtype:     str
+        """
+        prefix = "/RunConf_"
+        outdir = self.outdir+prefix+str(run)
+        postfix = ""
+        counter = 1
+        while os.path.exists(outdir+postfix):
+            counter+=1
+            postfix = "_"+str(counter)
+
+        return outdir+postfix+"/"
+
+    def _get_new_resume_file_name(self) -> str:
+        """
+        Create a new name for saving the runtime configuration each time resume is issued
+
+        :returns:   Path for the new resume file
+        :rtype:     str
+        """
+        postfix = ""
+        counter = 1
+        filename = self.thisrun_outdir+"/resume_parsed"
+        ext=".json"
+        while os.path.exists(filename+postfix+ext):
+            counter+=1
+            postfix = "_"+str(counter)
+
+        return filename+postfix+ext
+
+    def save_on_start(self, data: dict, run:int) -> str:
+        """
+        Save the configuration runtime start parameter set
+        :param      data:  The data
+        :type       data:  dict
+        :param      run :  run number
+        :type       run :  int
+
+        :returns:   Path of the saved config
+        :rtype:     str
+        """
+        self.thisrun_outdir = self._get_new_out_dir_name(run)
+        print(self.thisrun_outdir)
+        os.makedirs(self.thisrun_outdir)
+        copy_tree(self.cfg_dir, self.thisrun_outdir)
+
+        f = open(self.thisrun_outdir+"start_parsed.json", "w")
+        f.write(json.dumps(data, indent=2))
+        f.close()
+
+        return self.thisrun_outdir
+
+
+    def save_on_resume(self, data: dict) -> dict:
+        """
+        Generates runtime resume parameter set
+        :param      data:  The data
+        :type       data:  dict
+
+        :returns: None
+        """
+        f = open(self._get_new_resume_file_name(), "w")
+        f.write(json.dumps(data, indent=2))
+        f.close()
+
+
+
+if __name__ == "__main__":
+    import sys
+    from os.path import dirname, join
+    from rich.console import Console
+    from rich.pretty import Pretty
+    from rich.traceback import Traceback
+    import click
+
+    @click.command()
+    @click.argument('cfg_dir', type=click.Path(exists=True))
+    @click.argument('cfg_outdir', type=click.Path())
+    @click.argument('run', type=int)
+    def config_saver_test(cfg_dir, cfg_outdir, run):
+        instance = ConfigSaver(cfg_dir, cfg_outdir)
+        print(f"Save start data for run {run}")
+        runtime_start_data = {
+            "disable_data_storage": True,
+            "run": run,
+        }
+        instance.save_on_start(runtime_start_data, run)
+        print("Save resume data")
+        runtime_resume_data = {
+            "disable_data_storage": False
+        }
+        instance.save_on_resume(runtime_resume_data)
+        print(f"Data is in {cfg_outdir}")
+
+    config_saver_test()

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -20,7 +20,7 @@ class NanoRC:
         self.log = logging.getLogger(self.__class__.__name__)
         self.console = console
         self.cfg = ConfigManager(cfg_dir)
-        self.cfgsvr = ConfigSaver(cfg_dir, cfg_outdir)
+        self.cfgsvr = ConfigSaver(self.cfg, cfg_outdir)
         self.timeout = timeout
         self.return_code = 0
 

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -6,6 +6,7 @@ from rich.table import Table
 from rich.text import Text
 from .sshpm import SSHProcessManager
 from .cfgmgr import ConfigManager
+from .cfgsvr import ConfigSaver
 from .appctrl import AppSupervisor, ResponseListener
 from rich.traceback import Traceback
 
@@ -14,11 +15,12 @@ from typing import Union, NoReturn
 class NanoRC:
     """A Shonky RC for DUNE DAQ"""
 
-    def __init__(self, console: Console, cfg_dir: str, timeout:int):
+    def __init__(self, console: Console, cfg_dir: str, cfg_outdir: str, timeout:int):
         super(NanoRC, self).__init__()     
         self.log = logging.getLogger(self.__class__.__name__)
         self.console = console
         self.cfg = ConfigManager(cfg_dir)
+        self.cfgsvr = ConfigSaver(cfg_dir, cfg_outdir)
         self.timeout = timeout
         self.return_code = 0
 
@@ -165,11 +167,13 @@ class NanoRC:
         # if not trigger_interval_ticks is None:
         #     runtime_start_data["trigger_interval_ticks"] = trigger_interval_ticks
 
-        start_data, outdir = self.cfg.runtime_start(runtime_start_data)
+        start_data = self.cfg.runtime_start(runtime_start_data)
+        cfg_save_dir = self.cfgsvr.save_on_start(start_data, run)
+
         app_seq = getattr(self.cfg, 'start_order', None)
         ok, failed = self.send_many('start', start_data, 'CONFIGURED', 'RUNNING', sequence=app_seq, raise_on_fail=True)
         self.console.log(f"[bold magenta]Started run #{run}[/bold magenta]")
-        self.console.log(f"Saving run data in {outdir}")
+        self.console.log(f"Saving run data in {cfg_save_dir}")
 
 
     def stop(self) -> NoReturn:
@@ -202,6 +206,7 @@ class NanoRC:
             runtime_resume_data["trigger_interval_ticks"] = trigger_interval_ticks
 
         resume_data = self.cfg.runtime_resume(runtime_resume_data)
+        self.cfgsvr.save_on_resume(resume_data)
 
         app_seq = getattr(self.cfg, 'resume_order', None)
         ok, failed = self.send_many('resume', resume_data, 'RUNNING', 'RUNNING', sequence=app_seq, raise_on_fail=True)

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -165,9 +165,11 @@ class NanoRC:
         # if not trigger_interval_ticks is None:
         #     runtime_start_data["trigger_interval_ticks"] = trigger_interval_ticks
 
-        start_data = self.cfg.runtime_start(runtime_start_data)
+        start_data, outdir = self.cfg.runtime_start(runtime_start_data)
         app_seq = getattr(self.cfg, 'start_order', None)
         ok, failed = self.send_many('start', start_data, 'CONFIGURED', 'RUNNING', sequence=app_seq, raise_on_fail=True)
+        self.console.log(f"[bold magenta]Started run #{run}[/bold magenta]")
+        self.console.log(f"Saving run data in {outdir}")
 
 
     def stop(self) -> NoReturn:


### PR DESCRIPTION
This PR implements a simple way to save the config within the ConfigManager.

One specifies the place where the config should be saved at the top of the cfgmgr.py, then the code will automatically copy all the json in a directory called RunConf_{run_number}. It also saves the data that gets passed to the modules at the start and resume commands.

The runtime_start command now also returns the path where all this is saved, so that path can be put eventually be put in the run number database.