### PR TITLE
Expand environment variables found in data/*.json. 

### DIFF
--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -51,7 +51,9 @@ class ConfigManager:
 
             with open(fpath, "r") as jf:
                 try:
-                    j = json.load(jf)
+                    json_str = jf.read()
+                    json_str = os.path.expandvars(json_str)
+                    j = json.loads(json_str)
                     data[f] = j
                 except json.decoder.JSONDecodeError as e:
                     raise RuntimeError(f"ERROR: failed to load {f}.json") from e


### PR DESCRIPTION
This is necessary because the default value of the partition name is "${USER}_test", and this is copied into all of the NetworkMananger connection_name configurations.