### PR TITLE
Implement on host logging for the apps with nanorc

### DIFF
--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -102,7 +102,7 @@ def validatePath(ctx, param, prompted_path):
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--kerberos/--no-kerberos', default=True, help='Whether you want to use kerberos for communicating between processes')
 @click.option('--logbook-prefix', type=str, default="logbook", help='Prefix for the logbook file')
-@click.option('--log-path', type=str, default=os.getcwd(), help='Where the log should go (on the host where the app runs)')
+@click.option('--log-path', type=str, default=None, help='Where the log should go (on the host where the app runs)')
 @click.argument('top_cfg', type=click.Path(exists=True))
 @click.pass_obj
 @click.pass_context

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -102,10 +102,11 @@ def validatePath(ctx, param, prompted_path):
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--kerberos/--no-kerberos', default=True, help='Whether you want to use kerberos for communicating between processes')
 @click.option('--logbook-prefix', type=str, default="logbook", help='Prefix for the logbook file')
+@click.option('--log-path', type=str, default=os.getcwd(), help='Where the log should go (on the host where the app runs)')
 @click.argument('top_cfg', type=click.Path(exists=True))
 @click.pass_obj
 @click.pass_context
-def cli(ctx, obj, traceback, loglevel, timeout, cfg_dumpdir, logbook_prefix, kerberos, top_cfg):
+def cli(ctx, obj, traceback, loglevel, timeout, cfg_dumpdir, logbook_prefix, kerberos, log_path, top_cfg):
     obj.print_traceback = traceback
     credentials.user = 'user'
     ctx.command.shell.prompt = f'{credentials.user}@rc> '
@@ -132,6 +133,7 @@ def cli(ctx, obj, traceback, loglevel, timeout, cfg_dumpdir, logbook_prefix, ker
                     timeout = timeout,
                     use_kerb = kerberos,
                     logbook_prefix = logbook_prefix)
+        rc.log_path = log_path
 
     except Exception as e:
         logging.getLogger("cli").exception("Failed to build NanoRC")


### PR DESCRIPTION
When running `nanorc`, we cannot use the option `--log-path` and the logs are currently copied with ssh. This PR fixes that. By default, log-path is `None` (rather than PWD, as I thought initially), because if the apps run on a multi-host system which doesn't have access to PWD, we don't get undefined behaviour. Note that log-path already is in the production nanorc (`nano04rc`), in that case, the log path defaults to `/log`, these directories should exist on all the np04 machines.