### PR TITLE
Resolve #10 by adding --timeout option to commands

### DIFF
--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -34,7 +34,7 @@ from .cli import *
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--loglevel', type=click.Choice(loglevels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--log-path', type=click.Path(exists=True), default='/log', help='Where the logs should go (on localhost of applications)')
-@accept_timeout
+@accept_timeout(60)
 @click.option('--elisa-conf', type=click.Path(exists=True), default=None, help='ELisA configuration (by default, use the one in src/nanorc/confdata)')
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--dotnanorc', type=click.Path(), default="~/.nanorc.json", help='A JSON file which has auth/socket for the DB services')
@@ -133,7 +133,7 @@ def kinit(ctx, obj):
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
-@accept_timeout
+@accept_timeout(None)
 @click.pass_obj
 @click.pass_context
 def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
@@ -165,7 +165,7 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
-@accept_timeout
+@accept_timeout(None)
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):

--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -133,7 +133,7 @@ def kinit(ctx, obj):
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=0, help='stop timeout')
+@click.option('--timeout', type=int, default=None, help='stop timeout')
 @click.pass_obj
 @click.pass_context
 def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
@@ -165,7 +165,7 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=0, help='start timeout')
+@click.option('--timeout', type=int, default=None, help='start timeout')
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):

--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -133,17 +133,18 @@ def kinit(ctx, obj):
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
+@click.option('--timeout', type=int, default=0, help='stop timeout')
 @click.pass_obj
 @click.pass_context
-def stop(ctx, obj, stop_wait:int, force:bool, message:str):
+def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
     if not credentials.check_kerberos_credentials():
         logging.getLogger("cli").error(f'User {credentials.user} doesn\'t have valid kerberos ticket, use kinit to create a ticket (in a shell or in nanorc)')
         return
-    obj.rc.pause(force)
+    obj.rc.pause(force, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
     time.sleep(stop_wait)
-    obj.rc.stop(force, message=message)
+    obj.rc.stop(force, message=message, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
@@ -164,9 +165,10 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
+@click.option('--timeout', type=int, default=0, help='start timeout')
 @click.pass_obj
 @click.pass_context
-def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str):
+def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):
     """
     Start Command
 
@@ -178,11 +180,11 @@ def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger
         logging.getLogger("cli").error(f'User {credentials.user} doesn\'t have valid kerberos ticket, use kinit to create a ticket (in a shell or in nanorc)')
         return
 
-    obj.rc.start(disable_data_storage, run_type, message=message)
+    obj.rc.start(disable_data_storage, run_type, message=message, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
     time.sleep(resume_wait)
-    obj.rc.resume(trigger_interval_ticks)
+    obj.rc.resume(trigger_interval_ticks, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 

--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -34,7 +34,7 @@ from .cli import *
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--loglevel', type=click.Choice(loglevels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--log-path', type=click.Path(exists=True), default='/log', help='Where the logs should go (on localhost of applications)')
-@click.option('--timeout', type=int, default=60, help='Application commands timeout')
+@accept_timeout
 @click.option('--elisa-conf', type=click.Path(exists=True), default=None, help='ELisA configuration (by default, use the one in src/nanorc/confdata)')
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--dotnanorc', type=click.Path(), default="~/.nanorc.json", help='A JSON file which has auth/socket for the DB services')
@@ -133,7 +133,7 @@ def kinit(ctx, obj):
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=None, help='stop timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
@@ -165,7 +165,7 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=None, help='start timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -93,7 +93,7 @@ timingcli.add_command(wait, 'wait')
 timingcli.add_command(terminate, 'terminate')
 
 @timingcli.command('start')
-@click.option('--timeout', type=int, default=0, help='start timeout')
+@click.option('--timeout', type=int, default=None, help='start timeout')
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):
@@ -103,7 +103,7 @@ def start(ctx, obj, timeout:int):
 
 
 @timingcli.command('stop')
-@click.option('--timeout', type=int, default=0, help='stop timeout')
+@click.option('--timeout', type=int, default=None, help='stop timeout')
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -35,7 +35,7 @@ from .cli import *
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--loglevel', type=click.Choice(loglevels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--log-path', type=click.Path(exists=True), default=os.getcwd(), help='Where the logs should go (on localhost of applications)')
-@click.option('--timeout', type=int, default=60, help='Application commands timeout')
+@accept_timeout
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--kerberos/--no-kerberos', default=True, help='Whether you want to use kerberos for communicating between processes')
 @click.argument('cfg_dir', type=click.Path(exists=True))
@@ -93,7 +93,7 @@ timingcli.add_command(wait, 'wait')
 timingcli.add_command(terminate, 'terminate')
 
 @timingcli.command('start')
-@click.option('--timeout', type=int, default=None, help='start timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):
@@ -103,7 +103,7 @@ def start(ctx, obj, timeout:int):
 
 
 @timingcli.command('stop')
-@click.option('--timeout', type=int, default=None, help='stop timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -93,20 +93,22 @@ timingcli.add_command(wait, 'wait')
 timingcli.add_command(terminate, 'terminate')
 
 @timingcli.command('start')
+@click.option('--timeout', type=int, default=0, help='start timeout')
 @click.pass_obj
 @click.pass_context
-def start(ctx, obj):
-    obj.rc.start(disable_data_storage=True, run_type="TEST")
+def start(ctx, obj, timeout:int):
+    obj.rc.start(disable_data_storage=True, run_type="TEST", timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
 
 @timingcli.command('stop')
+@click.option('--timeout', type=int, default=0, help='stop timeout')
 @click.pass_obj
 @click.pass_context
-def start(ctx, obj):
+def start(ctx, obj, timeout:int):
     obj.rc.stop()
-    check_rc(ctx,obj)
+    check_rc(ctx,obj, timeout=timeout)
     obj.rc.status()
 
 

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -35,7 +35,7 @@ from .cli import *
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--loglevel', type=click.Choice(loglevels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
 @click.option('--log-path', type=click.Path(exists=True), default=os.getcwd(), help='Where the logs should go (on localhost of applications)')
-@accept_timeout
+@accept_timeout(60)
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--kerberos/--no-kerberos', default=True, help='Whether you want to use kerberos for communicating between processes')
 @click.argument('cfg_dir', type=click.Path(exists=True))
@@ -93,7 +93,7 @@ timingcli.add_command(wait, 'wait')
 timingcli.add_command(terminate, 'terminate')
 
 @timingcli.command('start')
-@accept_timeout
+@accept_timeout(None)
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):
@@ -103,7 +103,7 @@ def start(ctx, obj, timeout:int):
 
 
 @timingcli.command('stop')
-@accept_timeout
+@accept_timeout(None)
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -160,7 +160,7 @@ def status(obj: NanoContext):
     obj.rc.status()
 
 @cli.command('boot')
-@click.option('--timeout', type=int, default=0, help='boot timeout')
+@click.option('--timeout', type=int, default=None, help='boot timeout')
 @click.pass_obj
 @click.pass_context
 def boot(ctx, obj, timeout:int):
@@ -170,7 +170,7 @@ def boot(ctx, obj, timeout:int):
 
 @cli.command('init')
 @click.option('--path', type=str, default=None, callback=validatePath)
-@click.option('--timeout', type=int, default=0, help='init timeout')
+@click.option('--timeout', type=int, default=None, help='init timeout')
 @click.pass_obj
 @click.pass_context
 def init(ctx, obj, path, timeout:int):
@@ -186,7 +186,7 @@ def ls(obj):
 
 @cli.command('conf')
 @click.option('--path', type=str, default=None, callback=validatePath)
-@click.option('--timeout', type=int, default=0, help='conf timeout')
+@click.option('--timeout', type=int, default=None, help='conf timeout')
 @click.pass_obj
 @click.pass_context
 def conf(ctx, obj, path, timeout:int):
@@ -207,7 +207,7 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=0, help='start timeout')
+@click.option('--timeout', type=int, default=None, help='start timeout')
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):
@@ -235,7 +235,7 @@ def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_inte
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=0, help='stop timeout')
+@click.option('--timeout', type=int, default=None, help='stop timeout')
 @click.pass_obj
 @click.pass_context
 def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
@@ -248,7 +248,7 @@ def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
         obj.rc.status()
 
 @cli.command('pause')
-@click.option('--timeout', type=int, default=0, help='pause timeout')
+@click.option('--timeout', type=int, default=None, help='pause timeout')
 @click.pass_obj
 @click.pass_context
 def pause(ctx, obj, timeout:int):
@@ -258,7 +258,7 @@ def pause(ctx, obj, timeout:int):
 
 @cli.command('resume')
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
-@click.option('--timeout', type=int, default=0, help='resume timeout')
+@click.option('--timeout', type=int, default=None, help='resume timeout')
 @click.pass_obj
 @click.pass_context
 def resume(ctx, obj:NanoContext, trigger_interval_ticks:int, timeout:int):
@@ -276,7 +276,7 @@ def resume(ctx, obj:NanoContext, trigger_interval_ticks:int, timeout:int):
 @cli.command('scrap')
 @click.option('--path', type=str, default=None, callback=validatePath)
 @click.option('--force', default=False, is_flag=True)
-@click.option('--timeout', type=int, default=0, help='scrap timeout')
+@click.option('--timeout', type=int, default=None, help='scrap timeout')
 @click.pass_obj
 @click.pass_context
 def scrap(ctx, obj, path, force, timeout):

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -77,7 +77,7 @@ def updateLogLevel(loglevel):
         for handler in sh_command_logger.handlers:
             handler.setLevel(sh_command_level)
 
-def validate_timeout(ctx, timeout):
+def validate_timeout(ctx, param, timeout):
     if timeout is None:
         return timeout
     if timeout<=0:
@@ -353,8 +353,8 @@ def scrap(ctx, obj, timeout):
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def change_rate(ctx, obj, trigger_interval_ticks, timeout=timeout):
-    obj.rc.change_rate(trigger_interval_ticks)
+def change_rate(ctx, obj, trigger_interval_ticks, timeout):
+    obj.rc.change_rate(trigger_interval_ticks, timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
@@ -373,7 +373,7 @@ def enable(ctx, obj, path, timeout):
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def disable(ctx, obj, path):
+def disable(ctx, obj, path, timeout):
     obj.rc.disable(path, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -75,6 +75,15 @@ def updateLogLevel(loglevel):
         for handler in sh_command_logger.handlers:
             handler.setLevel(sh_command_level)
 
+def validate_timeout(ctx, timeout):
+    if timeout<=0:
+        raise click.BadParameter('Timeout should be >0')
+    return timeout
+
+def accept_timeout(function):
+    function = click.option('--timeout', type=int, default=30, help="Timeout, in seconds", callback=validate_timeout)(function)
+    return function
+
 def validatePath(ctx, param, prompted_path):
 
     if prompted_path is None:
@@ -101,11 +110,11 @@ def check_rc(ctx, obj):
 @click.version_option(__version__)
 @click.option('-t', '--traceback', is_flag=True, default=False, help='Print full exception traceback')
 @click.option('-l', '--loglevel', type=click.Choice(loglevels.keys(), case_sensitive=False), default='INFO', help='Set the log level')
-@click.option('--timeout', type=int, default=60, help='Application commands timeout')
 @click.option('--cfg-dumpdir', type=click.Path(), default="./", help='Path where the config gets copied on start')
 @click.option('--log-path', type=click.Path(exists=True), default=None, help='Where the logs should go (on localhost of applications)')
 @click.option('--kerberos/--no-kerberos', default=True, help='Whether you want to use kerberos for communicating between processes')
 @click.option('--logbook-prefix', type=str, default="logbook", help='Prefix for the logbook file')
+@accept_timeout
 @click.argument('top_cfg', type=click.Path(exists=True))
 @click.pass_obj
 @click.pass_context
@@ -160,7 +169,7 @@ def status(obj: NanoContext):
     obj.rc.status()
 
 @cli.command('boot')
-@click.option('--timeout', type=int, default=None, help='boot timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def boot(ctx, obj, timeout:int):
@@ -170,7 +179,7 @@ def boot(ctx, obj, timeout:int):
 
 @cli.command('init')
 @click.option('--path', type=str, default=None, callback=validatePath)
-@click.option('--timeout', type=int, default=None, help='init timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def init(ctx, obj, path, timeout:int):
@@ -186,7 +195,7 @@ def ls(obj):
 
 @cli.command('conf')
 @click.option('--path', type=str, default=None, callback=validatePath)
-@click.option('--timeout', type=int, default=None, help='conf timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def conf(ctx, obj, path, timeout:int):
@@ -207,7 +216,7 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=None, help='start timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):
@@ -235,7 +244,7 @@ def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_inte
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
-@click.option('--timeout', type=int, default=None, help='stop timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
@@ -248,7 +257,7 @@ def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
         obj.rc.status()
 
 @cli.command('pause')
-@click.option('--timeout', type=int, default=None, help='pause timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def pause(ctx, obj, timeout:int):
@@ -258,7 +267,7 @@ def pause(ctx, obj, timeout:int):
 
 @cli.command('resume')
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
-@click.option('--timeout', type=int, default=None, help='resume timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def resume(ctx, obj:NanoContext, trigger_interval_ticks:int, timeout:int):
@@ -276,7 +285,7 @@ def resume(ctx, obj:NanoContext, trigger_interval_ticks:int, timeout:int):
 @cli.command('scrap')
 @click.option('--path', type=str, default=None, callback=validatePath)
 @click.option('--force', default=False, is_flag=True)
-@click.option('--timeout', type=int, default=None, help='scrap timeout')
+@accept_timeout
 @click.pass_obj
 @click.pass_context
 def scrap(ctx, obj, path, force, timeout):

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -160,19 +160,21 @@ def status(obj: NanoContext):
     obj.rc.status()
 
 @cli.command('boot')
+@click.option('--timeout', type=int, default=0, help='boot timeout')
 @click.pass_obj
 @click.pass_context
-def boot(ctx, obj):
-    obj.rc.boot()
+def boot(ctx, obj, timeout:int):
+    obj.rc.boot(timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
 @cli.command('init')
 @click.option('--path', type=str, default=None, callback=validatePath)
+@click.option('--timeout', type=int, default=0, help='init timeout')
 @click.pass_obj
 @click.pass_context
-def init(ctx, obj, path):
-    obj.rc.init(path)
+def init(ctx, obj, path, timeout:int):
+    obj.rc.init(path, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
@@ -184,10 +186,11 @@ def ls(obj):
 
 @cli.command('conf')
 @click.option('--path', type=str, default=None, callback=validatePath)
+@click.option('--timeout', type=int, default=0, help='conf timeout')
 @click.pass_obj
 @click.pass_context
-def conf(ctx, obj, path):
-    obj.rc.conf(path)
+def conf(ctx, obj, path, timeout:int):
+    obj.rc.conf(path, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
@@ -204,9 +207,10 @@ def message(obj, message):
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
 @click.option('--message', type=str, default="")
+@click.option('--timeout', type=int, default=0, help='start timeout')
 @click.pass_obj
 @click.pass_context
-def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str):
+def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):
     """
     Start Command
 
@@ -218,50 +222,53 @@ def start(ctx, obj:NanoContext, run:int, disable_data_storage:bool, trigger_inte
     """
 
     obj.rc.run_num_mgr.set_run_number(run)
-    obj.rc.start(disable_data_storage, "TEST", message=message)
+    obj.rc.start(disable_data_storage, "TEST", message=message, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
     time.sleep(resume_wait)
     if obj.rc.return_code == 0:
         time.sleep(resume_wait)
-        obj.rc.resume(trigger_interval_ticks)
+        obj.rc.resume(trigger_interval_ticks, timeout=timeout)
         obj.rc.status()
 
 @cli.command('stop')
 @click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
 @click.option('--force', default=False, is_flag=True)
 @click.option('--message', type=str, default="")
+@click.option('--timeout', type=int, default=0, help='stop timeout')
 @click.pass_obj
 @click.pass_context
-def stop(ctx, obj, stop_wait:int, force:bool, message:str):
-    obj.rc.pause(force)
+def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
+    obj.rc.pause(force, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
     time.sleep(stop_wait)
     if obj.rc.return_code == 0:
-        obj.rc.stop(force, message=message)
+        obj.rc.stop(force, message=message, timeout=timeout)
         obj.rc.status()
 
 @cli.command('pause')
+@click.option('--timeout', type=int, default=0, help='pause timeout')
 @click.pass_obj
 @click.pass_context
-def pause(ctx, obj):
-    obj.rc.pause()
+def pause(ctx, obj, timeout:int):
+    obj.rc.pause(timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
 @cli.command('resume')
 @click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
+@click.option('--timeout', type=int, default=0, help='resume timeout')
 @click.pass_obj
 @click.pass_context
-def resume(ctx, obj:NanoContext, trigger_interval_ticks:int):
+def resume(ctx, obj:NanoContext, trigger_interval_ticks:int, timeout:int):
     """Resume Command
 
     Args:
         obj (NanoContext): Context object
         trigger_interval_ticks (int): Trigger separation in ticks
     """
-    obj.rc.resume(trigger_interval_ticks)
+    obj.rc.resume(trigger_interval_ticks, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 
@@ -269,10 +276,11 @@ def resume(ctx, obj:NanoContext, trigger_interval_ticks:int):
 @cli.command('scrap')
 @click.option('--path', type=str, default=None, callback=validatePath)
 @click.option('--force', default=False, is_flag=True)
+@click.option('--timeout', type=int, default=0, help='scrap timeout')
 @click.pass_obj
 @click.pass_context
-def scrap(ctx, obj, path, force):
-    obj.rc.scrap(path, force)
+def scrap(ctx, obj, path, force, timeout):
+    obj.rc.scrap(path, force, timeout=timeout)
     check_rc(ctx,obj)
     obj.rc.status()
 

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -88,7 +88,7 @@ class NanoRC:
         if not timeout:
             timeout = self.timeout
         ret = self.topnode.send_custom_command(command, data, timeout=timeout)
-        self.console.log(ret)
+        self.log.debug(ret)
 
     def send_expert_command(self, app, json_file, timeout):
         if not timeout:
@@ -340,27 +340,27 @@ class NanoRC:
         """
         Start the triggers
         """
-        self.topnode.send_custom_command("start_trigger",
-                                         data={'trigger_interval_ticks':trigger_interval_ticks,},
-                                         timeout=timeout)
+        self.execute_custom_command("start_trigger",
+                                    data={'trigger_interval_ticks':trigger_interval_ticks,},
+                                    timeout=timeout)
 
 
     def stop_trigger(self, timeout) -> NoReturn:
         """
         Stop the triggers
         """
-        self.topnode.send_custom_command("stop_trigger",
-                                         data={},
-                                         timeout=timeout)
+        self.execute_custom_command("stop_trigger",
+                                    data={},
+                                    timeout=timeout)
 
 
     def change_rate(self, trigger_interval_ticks, timeout) -> NoReturn:
         """
         Start the triggers
         """
-        self.topnode.send_custom_command("change_rate",
-                                         data={'trigger_interval_ticks':trigger_interval_ticks},
-                                         timeout=timeout)
+        self.execute_custom_command("change_rate",
+                                    data={'trigger_interval_ticks':trigger_interval_ticks},
+                                    timeout=timeout)
 
 
     def disable(self, node, timeout) -> NoReturn:
@@ -368,9 +368,9 @@ class NanoRC:
         Start the triggers
         """
         node.disable()
-        node.send_custom_command("disable",
-                                 data={'name':node.name},
-                                 timeout=timeout)
+        self.execute_custom_command("disable",
+                                    data={'name':node.name},
+                                    timeout=timeout)
 
 
     def enable(self, node, timeout) -> NoReturn:
@@ -378,6 +378,6 @@ class NanoRC:
         Start the triggers
         """
         node.enable()
-        node.send_custom_command("enable",
-                                 data={'name':node.name},
-                                 timeout=timeout)
+        self.execute_custom_command("enable",
+                                    data={'name':node.name},
+                                    timeout=timeout)

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -82,6 +82,8 @@ class NanoRC:
         if not self.can_transition(command):
             return
 
+        if 'timeout' in kwargs:
+            kwargs['timeout'] = kwargs['timeout'] if kwargs['timeout'] is not None else self.timeout
         transition = getattr(self.topnode, command)
         transition(*args, **kwargs)
         self.return_code = self.topnode.return_code.value
@@ -105,12 +107,11 @@ class NanoRC:
         self.return_code = print_node(node=self.topnode, console=self.console, leg=leg)
 
 
-    def boot(self, timeout:int=0) -> NoReturn:
+    def boot(self, timeout:int=None) -> NoReturn:
         """
         Boots applications
         """
-        cmd_timeout = timeout if timeout != 0 else self.timeout
-        self.execute_command("boot", timeout=cmd_timeout, log=self.log_path)
+        self.execute_command("boot", timeout=timeout, log=self.log_path)
 
 
     def terminate(self) -> NoReturn:
@@ -120,39 +121,35 @@ class NanoRC:
         self.execute_command("terminate")
 
 
-    def init(self, path, timeout:int=0) -> NoReturn:
+    def init(self, path, timeout:int=None) -> NoReturn:
         """
         Initializes the applications.
         """
-        cmd_timeout = timeout if timeout != 0 else self.timeout
-        self.execute_command("init", path=path, raise_on_fail=True, timeout=cmd_timeout)
+        self.execute_command("init", path=path, raise_on_fail=True, timeout=timeout)
 
 
-    def conf(self, path, timeout:int=0) -> NoReturn:
+    def conf(self, path, timeout:int=None) -> NoReturn:
         """
         Sends configure command to the applications.
         """
-        cmd_timeout = timeout if timeout != 0 else self.timeout
-        self.execute_command("conf", path=path, raise_on_fail=True, timeout=cmd_timeout)
+        self.execute_command("conf", path=path, raise_on_fail=True, timeout=timeout)
 
 
-    def pause(self, force:bool=False, timeout:int=0) -> NoReturn:
+    def pause(self, force:bool=False, timeout:int=None) -> NoReturn:
         """
         Sends pause command
         """
-        cmd_timeout = timeout if timeout != 0 else self.timeout
-        self.execute_command("pause", path=None, raise_on_fail=True, timeout=cmd_timeout, force=force)
+        self.execute_command("pause", path=None, raise_on_fail=True, timeout=timeout, force=force)
 
 
-    def scrap(self, path, force:bool=False, timeout:int=0) -> NoReturn:
+    def scrap(self, path, force:bool=False, timeout:int=None) -> NoReturn:
         """
         Send scrap command
         """
-        cmd_timeout = timeout if timeout != 0 else self.timeout
-        self.execute_command("scrap", path=None, raise_on_fail=True, timeout=cmd_timeout, force=force)
+        self.execute_command("scrap", path=None, raise_on_fail=True, timeout=timeout, force=force)
 
 
-    def start(self, disable_data_storage: bool, run_type:str, message:str="", timeout:int=0) -> NoReturn:
+    def start(self, disable_data_storage: bool, run_type:str, message:str="", timeout:int=None) -> NoReturn:
         """
         Sends start command to the applications
 
@@ -194,11 +191,10 @@ class NanoRC:
                 self.return_code = 1
                 return
 
-        cmd_timeout = timeout if timeout != 0 else self.timeout
         self.topnode.start(path=None, raise_on_fail=True,
                            cfg_method="runtime_start",
                            overwrite_data=runtime_start_data,
-                           timeout=cmd_timeout)
+                           timeout=timeout)
 
         self.return_code = self.topnode.return_code.value
         if self.return_code == 0:
@@ -228,7 +224,7 @@ class NanoRC:
                 self.log.error(f"Couldn't make an entry to elisa, do it yourself manually at {self.logbook.website}\nError text:\n{str(e)}")
 
 
-    def stop(self, force:bool=False, message:str="", timeout:int=0) -> NoReturn:
+    def stop(self, force:bool=False, message:str="", timeout:int=None) -> NoReturn:
         """
         Sends stop command
         """
@@ -246,8 +242,7 @@ class NanoRC:
         if self.cfgsvr:
             self.cfgsvr.save_on_stop(self.run)
 
-        cmd_timeout = timeout if timeout != 0 else self.timeout
-        self.topnode.stop(path=None, raise_on_fail=True, timeout=cmd_timeout, force=force)
+        self.topnode.stop(path=None, raise_on_fail=True, timeout=timeout, force=force)
         self.return_code = self.topnode.return_code.value
 
         if self.return_code == 0:
@@ -259,7 +254,7 @@ class NanoRC:
 
 
 
-    def resume(self, trigger_interval_ticks: Union[int, None], timeout:int=0) -> NoReturn:
+    def resume(self, trigger_interval_ticks: Union[int, None], timeout:int=None) -> NoReturn:
         """
         Sends resume command
 
@@ -278,9 +273,8 @@ class NanoRC:
                                    overwrite_data=runtime_resume_data,
                                    cfg_method="runtime_resume")
 
-        cmd_timeout = timeout if timeout != 0 else self.timeout
         self.topnode.resume(path=None, raise_on_fail=True,
                             cfg_method="runtime_resume",
                             overwrite_data=runtime_resume_data,
-                            timeout=cmd_timeout)
+                            timeout=timeout)
         self.return_code = self.topnode.return_code.value

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -82,8 +82,8 @@ class NanoRC:
         if not self.can_transition(command):
             return
 
-        if 'timeout' in kwargs:
-            kwargs['timeout'] = kwargs['timeout'] if kwargs['timeout'] is not None else self.timeout
+        kwargs['timeout'] = kwargs['timeout'] if kwargs.get('timeout') else self.timeout
+        self.log.debug(f'Using timeout = {kwargs["timeout"]}')
         transition = getattr(self.topnode, command)
         transition(*args, **kwargs)
         self.return_code = self.topnode.return_code.value
@@ -114,11 +114,11 @@ class NanoRC:
         self.execute_command("boot", timeout=timeout, log=self.log_path)
 
 
-    def terminate(self) -> NoReturn:
+    def terminate(self, timeout:int=None) -> NoReturn:
         """
         Terminates applications (but keep all the subsystems structure)
         """
-        self.execute_command("terminate")
+        self.execute_command("terminate", timeout=timeout)
 
 
     def init(self, path, timeout:int=None) -> NoReturn:

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -105,11 +105,12 @@ class NanoRC:
         self.return_code = print_node(node=self.topnode, console=self.console, leg=leg)
 
 
-    def boot(self) -> NoReturn:
+    def boot(self, timeout:int=0) -> NoReturn:
         """
         Boots applications
         """
-        self.execute_command("boot", timeout=self.timeout, log=self.log_path)
+        cmd_timeout = timeout if timeout != 0 else self.timeout
+        self.execute_command("boot", timeout=cmd_timeout, log=self.log_path)
 
 
     def terminate(self) -> NoReturn:
@@ -119,35 +120,39 @@ class NanoRC:
         self.execute_command("terminate")
 
 
-    def init(self, path) -> NoReturn:
+    def init(self, path, timeout:int=0) -> NoReturn:
         """
         Initializes the applications.
         """
-        self.execute_command("init", path=path, raise_on_fail=True, timeout=self.timeout)
+        cmd_timeout = timeout if timeout != 0 else self.timeout
+        self.execute_command("init", path=path, raise_on_fail=True, timeout=cmd_timeout)
 
 
-    def conf(self, path) -> NoReturn:
+    def conf(self, path, timeout:int=0) -> NoReturn:
         """
         Sends configure command to the applications.
         """
-        self.execute_command("conf", path=path, raise_on_fail=True, timeout=self.timeout)
+        cmd_timeout = timeout if timeout != 0 else self.timeout
+        self.execute_command("conf", path=path, raise_on_fail=True, timeout=cmd_timeout)
 
 
-    def pause(self, force:bool=False) -> NoReturn:
+    def pause(self, force:bool=False, timeout:int=0) -> NoReturn:
         """
         Sends pause command
         """
-        self.execute_command("pause", path=None, raise_on_fail=True, timeout=self.timeout, force=force)
+        cmd_timeout = timeout if timeout != 0 else self.timeout
+        self.execute_command("pause", path=None, raise_on_fail=True, timeout=cmd_timeout, force=force)
 
 
-    def scrap(self, path, force:bool=False) -> NoReturn:
+    def scrap(self, path, force:bool=False, timeout:int=0) -> NoReturn:
         """
         Send scrap command
         """
-        self.execute_command("scrap", path=None, raise_on_fail=True, timeout=self.timeout, force=force)
+        cmd_timeout = timeout if timeout != 0 else self.timeout
+        self.execute_command("scrap", path=None, raise_on_fail=True, timeout=cmd_timeout, force=force)
 
 
-    def start(self, disable_data_storage: bool, run_type:str, message:str="") -> NoReturn:
+    def start(self, disable_data_storage: bool, run_type:str, message:str="", timeout:int=0) -> NoReturn:
         """
         Sends start command to the applications
 
@@ -189,10 +194,11 @@ class NanoRC:
                 self.return_code = 1
                 return
 
+        cmd_timeout = timeout if timeout != 0 else self.timeout
         self.topnode.start(path=None, raise_on_fail=True,
                            cfg_method="runtime_start",
                            overwrite_data=runtime_start_data,
-                           timeout=self.timeout)
+                           timeout=cmd_timeout)
 
         self.return_code = self.topnode.return_code.value
         if self.return_code == 0:
@@ -222,7 +228,7 @@ class NanoRC:
                 self.log.error(f"Couldn't make an entry to elisa, do it yourself manually at {self.logbook.website}\nError text:\n{str(e)}")
 
 
-    def stop(self, force:bool=False, message:str="") -> NoReturn:
+    def stop(self, force:bool=False, message:str="", timeout:int=0) -> NoReturn:
         """
         Sends stop command
         """
@@ -240,7 +246,8 @@ class NanoRC:
         if self.cfgsvr:
             self.cfgsvr.save_on_stop(self.run)
 
-        self.topnode.stop(path=None, raise_on_fail=True, timeout=self.timeout, force=force)
+        cmd_timeout = timeout if timeout != 0 else self.timeout
+        self.topnode.stop(path=None, raise_on_fail=True, timeout=cmd_timeout, force=force)
         self.return_code = self.topnode.return_code.value
 
         if self.return_code == 0:
@@ -252,7 +259,7 @@ class NanoRC:
 
 
 
-    def resume(self, trigger_interval_ticks: Union[int, None]) -> NoReturn:
+    def resume(self, trigger_interval_ticks: Union[int, None], timeout:int=0) -> NoReturn:
         """
         Sends resume command
 
@@ -271,8 +278,9 @@ class NanoRC:
                                    overwrite_data=runtime_resume_data,
                                    cfg_method="runtime_resume")
 
+        cmd_timeout = timeout if timeout != 0 else self.timeout
         self.topnode.resume(path=None, raise_on_fail=True,
                             cfg_method="runtime_resume",
                             overwrite_data=runtime_resume_data,
-                            timeout=self.timeout)
+                            timeout=cmd_timeout)
         self.return_code = self.topnode.return_code.value

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -336,7 +336,7 @@ class NanoRC:
         self.return_code = self.topnode.return_code.value
 
 
-    def start_trigger(self, trigger_interval_ticks: Union[int, None], timeout=timeout) -> NoReturn:
+    def start_trigger(self, trigger_interval_ticks: Union[int, None], timeout) -> NoReturn:
         """
         Start the triggers
         """
@@ -345,7 +345,7 @@ class NanoRC:
                                          timeout=timeout)
 
 
-    def stop_trigger(self) -> NoReturn:
+    def stop_trigger(self, timeout) -> NoReturn:
         """
         Stop the triggers
         """
@@ -354,7 +354,7 @@ class NanoRC:
                                          timeout=timeout)
 
 
-    def change_rate(self, trigger_interval_ticks) -> NoReturn:
+    def change_rate(self, trigger_interval_ticks, timeout) -> NoReturn:
         """
         Start the triggers
         """
@@ -363,7 +363,7 @@ class NanoRC:
                                          timeout=timeout)
 
 
-    def disable(self, node) -> NoReturn:
+    def disable(self, node, timeout) -> NoReturn:
         """
         Start the triggers
         """
@@ -373,7 +373,7 @@ class NanoRC:
                                  timeout=timeout)
 
 
-    def enable(self, node) -> NoReturn:
+    def enable(self, node, timeout) -> NoReturn:
         """
         Start the triggers
         """

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -57,7 +57,8 @@ class SubsystemNode(StatefulNode):
         try:
             if self.pm is None:
                 self.pm = SSHProcessManager(self.console, self.ssh_conf)
-            self.pm.boot(self.cfgmgr.boot, event.kwargs.get('log'))
+            timeout = event.kwargs["timeout"]
+            self.pm.boot(self.cfgmgr.boot, event.kwargs.get('log'), timeout)
         except Exception as e:
             self.console.print_exception()
 

--- a/src/nanorc/sshpm.py
+++ b/src/nanorc/sshpm.py
@@ -138,7 +138,7 @@ class SSHProcessManager(object):
         self.log.debug(name+str(exc))
         self.event_queue.put((name, exc))
 
-    def boot(self, boot_info, log=None):
+    def boot(self, boot_info, log=None, timeout=30):
 
         if self.apps:
             raise RuntimeError(
@@ -220,7 +220,6 @@ class SSHProcessManager(object):
             self.watch(name, proc)
             desc.proc = proc
 
-        timeout = 30
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),


### PR DESCRIPTION
Also uses system timeout for `boot` instead of hard-coded 30 seconds.