### PR TITLE
branch off of plasorak/k8s-np04-cluster to set host_pid -- to allow T…

### DIFF
--- a/src/nanorc/k8spm.py
+++ b/src/nanorc/k8spm.py
@@ -189,6 +189,7 @@ class K8SProcessManager(object):
                     run_as_user=run_as['uid'],
                     run_as_group=run_as['gid'],
                 ) if run_as else None,
+                host_pid=True,
                 affinity=client.V1Affinity(
                     node_affinity = client.V1NodeAffinity(
                         required_during_scheduling_ignored_during_execution=client.V1NodeSelector(


### PR DESCRIPTION
Can be merged into plasorak/k8s-np04-cluster
Sets host_pid to allow TRACEing multiple daq_applications on a host -- and including kernel task switch
TRACEing