### PR TITLE
Partition name specified in nanorc cli rather than at boot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/0XzhExSIMQJUsp0/downlo
 Generate a configuration:
 
 ```bash 
-daqconf_multiru_gen fake_daq partition-name
+daqconf_multiru_gen fake_daq
 ```
 
 Next (if you want to), you can create a file called `top_level.json` which contains:
@@ -39,7 +39,7 @@ Now you're ready to run.
 
 To see a list of options you can pass nanorc in order to control things such as the amount of information it prints and the timeouts for transitions, run `nanorc -h`. We'll skip those for now in the following demo:
 ```
-nanorc top_level.json # or "nanorc fake_daq" if you didn't create the top_level.json
+nanorc top_level.json partition-name# or "nanorc fake_daq partition-name" if you didn't create the top_level.json
 
 ╭──────────────────────────────────────────────────────────────────────────╮
 │                              Shonky NanoRC                               │
@@ -114,7 +114,7 @@ nanorc commands can be autocompleted with TAB, for example, TAB will autocomplet
 You can also control nanorc in "batch mode", e.g.:
 ```
 run_number=999
-nanorc mdapp_fake boot init conf start --disable-data-storage $run_number wait 2 resume wait 60 pause wait 2 stop scrap terminate
+nanorc mdapp_fake partition-name boot init conf start --disable-data-storage $run_number wait 2 resume wait 60 pause wait 2 stop scrap terminate
 ```
 Notice the ability to control the time via transitions from the command line via the `wait` argument. 
 
@@ -216,5 +216,4 @@ It should be pointed out that some substitutions are made when nanorc uses a fil
 
 ## How to run WebUI
 
-WebUI running is handled by `nanocrestrc` command. WebUI needs you to provide only one parameter in addition.
-* `-s` - serveraddress - as your browser is running on your side, it needs the information where to find REST endpoints. Simply provide address of the interface of the computer you are running the server on. Default value is `localhost`
+WebUI running is handled by `nanorc --web` command. WebUI needs you to provide only one parameter in addition.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,13 +15,13 @@ First, set up a working area according to [the daq-buildtools instructions](http
 Get the example data file:
 
 ```bash
-curl https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download -o frames.bin
+curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/0XzhExSIMQJUsp0/download
 ```
 
 Generate a configuration:
 
 ```bash 
-daqconf_multiru_gen fake_daq
+daqconf_multiru_gen fake_daq partition-name
 ```
 
 Next (if you want to), you can create a file called `top_level.json` which contains:

--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -45,9 +45,10 @@ from .cli import *
 @click.option('--partition-number', type=int, default=0, help='Which partition number to run', callback=argval.validate_partition_number)
 @click.argument('cfg_dir', type=str, callback=argval.validate_conf)
 @click.argument('user', type=str)
+@click.argument('partition-label', type=str, callback=argval.validate_partition)
 @click.pass_obj
 @click.pass_context
-def np04cli(ctx, obj, traceback, loglevel, elisa_conf, log_path, cfg_dumpdir, dotnanorc, kerberos, timeout, partition_number, web, pm, cfg_dir, user):
+def np04cli(ctx, obj, traceback, loglevel, elisa_conf, log_path, cfg_dumpdir, dotnanorc, kerberos, timeout, partition_number, partition_label, web, pm, cfg_dir, user):
 
     if not elisa_conf:
         with resources.path(confdata, "elisa_conf.json") as p:
@@ -92,15 +93,18 @@ def np04cli(ctx, obj, traceback, loglevel, elisa_conf, log_path, cfg_dumpdir, do
         logging.getLogger("cli").info("RunDB socket "+rundb_socket)
         logging.getLogger("cli").info("RunRegistryDB socket "+runreg_socket)
 
-        rc = NanoRC(console = obj.console,
-                    top_cfg = cfg_dir,
-                    run_num_mgr = DBRunNumberManager(rundb_socket),
-                    run_registry = DBConfigSaver(runreg_socket),
-                    logbook_type = elisa_conf,
-                    timeout = timeout,
-                    use_kerb = kerberos,
-                    port_offset = port_offset,
-                    pm = pm)
+        rc = NanoRC(
+            console = obj.console,
+            top_cfg = cfg_dir,
+            partition_label = partition_label,
+            run_num_mgr = DBRunNumberManager(rundb_socket),
+            run_registry = DBConfigSaver(runreg_socket),
+            logbook_type = elisa_conf,
+            timeout = timeout,
+            use_kerb = kerberos,
+            port_offset = port_offset,
+            pm = pm
+        )
 
         rc.log_path = os.path.abspath(log_path)
         add_custom_cmds(ctx.command, rc.execute_custom_command, rc.custom_cmd)

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -43,9 +43,10 @@ from .cli import *
 @click.option('--web/--no-web', is_flag=True, default=False, help='whether to spawn webui')
 @click.option('--pm', type=str, default="ssh://", help='Process manager, can be: ssh://, kind://, or k8s://np04-srv-015:31000, for example', callback=argval.validate_pm)
 @click.argument('cfg_dir', type=str, callback=argval.validate_conf)
+@click.argument('partition-label', type=str, callback=argval.validate_partition)
 @click.pass_obj
 @click.pass_context
-def timingcli(ctx, obj, traceback, pm, loglevel, log_path, cfg_dumpdir, kerberos, timeout, partition_number, web, cfg_dir):
+def timingcli(ctx, obj, traceback, pm, loglevel, log_path, cfg_dumpdir, kerberos, timeout, partition_number, partition_label, web, cfg_dir):
     obj.print_traceback = traceback
     credentials.user = 'user'
     ctx.command.shell.prompt = f"{credentials.user}@timingrc> "
@@ -70,6 +71,7 @@ def timingcli(ctx, obj, traceback, pm, loglevel, log_path, cfg_dumpdir, kerberos
     try:
         rc = NanoRC(
             console = obj.console,
+            partition_label = partition_label,
             fsm_cfg = "timing",
             top_cfg = cfg_dir,
             run_num_mgr = None,

--- a/src/nanorc/argval.py
+++ b/src/nanorc/argval.py
@@ -52,9 +52,6 @@ def validate_partition_number(ctx, param, number):
     return number
 
 def validate_partition(ctx, param, partition):
-    if ctx.obj.rc.pm.use_k8spm() and not partition:
-        raise click.BadParameter(f'You need to feed a partition to run with k8s')
-
     pat = re.compile(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?') ## Nanorc-12334 allowed (with hyphen) This is straight from k8s error message when the partition name isn't right
     if not re.fullmatch(pat, partition):
         raise click.BadParameter(f'Partition {partition} should be alpha-numeric-hyphen! Make sure you name has the form [a-z0-9]([-a-z0-9]*[a-z0-9])?')

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -140,7 +140,6 @@ def add_custom_cmds(cli, rc_cmd_exec, cmds):
 @click.pass_obj
 @click.pass_context
 def cli(ctx, obj, traceback, loglevel, cfg_dumpdir, log_path, logbook_prefix, timeout, kerberos, partition_number, web, top_cfg, partition_label, pm):
-    print(f"pm, {pm}")
     obj.print_traceback = traceback
     credentials.user = 'user'
     ctx.command.shell.prompt = f'{credentials.user}@rc> '

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -40,7 +40,7 @@ import dunedaq.cmdlib.cmd as cmd  # AddressedCmd,
 class NanoRC:
     """A Shonky RC for DUNE DAQ"""
 
-    def __init__(self, console: Console, top_cfg: str, run_num_mgr, run_registry, logbook_type:str, timeout: int,
+    def __init__(self, console: Console, top_cfg: str, partition_label:str, run_num_mgr, run_registry, logbook_type:str, timeout: int,
                  use_kerb=True, logbook_prefix="", fsm_cfg="partition", port_offset=0,
                  pm=None):
         super(NanoRC, self).__init__()
@@ -59,7 +59,7 @@ class NanoRC:
             fsm_conf=fsm_cfg,
             resolve_hostname = pm.use_sshpm(),
             port_offset=self.port_offset)
-        self.partition = None
+        self.partition = partition_label
 
         self.custom_cmd = self.cfg.get_custom_commands()
         self.console.print(f'Extra commands are {list(self.custom_cmd.keys())}')
@@ -194,14 +194,13 @@ class NanoRC:
         self.return_code = print_node(node=self.topnode, console=self.console, leg=leg)
 
 
-    def boot(self, partition:str, timeout:int=None) -> NoReturn:
+    def boot(self, timeout:int=None) -> NoReturn:
         """
         Boot applications
         """
-        self.partition=partition
         self.execute_command(
             "boot",
-            partition=partition,
+            partition=self.partition,
             timeout=timeout,
             ssh_conf=self.ssh_conf,
             log_path=self.log_path,


### PR DESCRIPTION
Fixes https://github.com/DUNE-DAQ/nanorc/issues/97
Now the user has to do:
```
nanorc top.json partition-name
nano04rc top.json uname partition-name
nanotimingrc top.json partition-name
```