### PR TITLE
Plasorak/extra stop command

### DIFF
--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -208,13 +208,13 @@ def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
         logging.getLogger("cli").error(f'User {credentials.user} doesn\'t have valid kerberos ticket, use kinit to create a ticket (in a shell or in nanorc)')
         return
     obj.rc.pause(force, timeout=timeout)
-    check_rc(ctx,obj)
+    check_rc(ctx,obj.rc)
     obj.rc.status()
     if obj.rc.return_code == 0:
         time.sleep(stop_wait)
         obj.rc.stop(force, message=message, timeout=timeout)
         obj.rc.status()
-    check_rc(ctx,obj)
+    check_rc(ctx,obj.rc)
 
 
 @np04cli.command('message')
@@ -249,13 +249,13 @@ def start(ctx, obj:NanoContext, run_type:str, disable_data_storage:bool, trigger
         return
 
     obj.rc.start(disable_data_storage, run_type, message=message, timeout=timeout)
-    check_rc(ctx,obj)
+    check_rc(ctx,obj.rc)
     time.sleep(resume_wait)
     if obj.rc.return_code == 0:
         obj.rc.status()
         obj.rc.resume(trigger_interval_ticks, timeout=timeout)
         obj.rc.status()
-    check_rc(ctx,obj)
+    check_rc(ctx,obj.rc)
 
 
 def main():

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -157,7 +157,7 @@ timingcli.add_command(start_shell, 'shell')
 @click.pass_context
 def start(ctx, obj, timeout:int):
     obj.rc.start(disable_data_storage=True, run_type="TEST", timeout=timeout)
-    check_rc(ctx,obj)
+    check_rc(ctx,obj.rc)
     obj.rc.status()
 
 
@@ -167,7 +167,7 @@ def start(ctx, obj, timeout:int):
 @click.pass_context
 def start(ctx, obj, timeout:int):
     obj.rc.stop(timeout=timeout)
-    check_rc(ctx,obj)
+    check_rc(ctx,obj.rc)
     obj.rc.status()
 
 

--- a/src/nanorc/argval.py
+++ b/src/nanorc/argval.py
@@ -19,6 +19,11 @@ def validate_timeout(ctx, param, timeout):
         raise click.BadParameter('Timeout should be >0')
     return timeout
 
+def validate_wait(ctx, param, wait):
+    if wait<0:
+        raise click.BadParameter('Wait should be >=0')
+    return wait
+
 def validate_stop_wait(ctx, param, stop_wait):
     if stop_wait is None:
         return stop_wait

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -121,7 +121,7 @@ class ConfigManager:
     def _load(self) -> None:
 
         pm_cfg = ["boot"]
-        rc_cmds = ["init", "conf", "start", "stop", "pause", "resume", "scrap"]
+        rc_cmds = ["init", "conf", "start", "stop_trigger", "prestop1", "prestop2", "stop", "pause", "resume", "scrap"]
         cfgs = {}
         for f in pm_cfg + rc_cmds:
             fpath = os.path.join(self.cfg_dir, f + ".json")

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -48,6 +48,7 @@ class ConfigManager:
 
     def __init__(self, log, config, resolve_hostname=True, port_offset=0):
         super().__init__()
+        self.conf_dirs = []
         self.resolve_hostname = resolve_hostname
         self.log = log
 
@@ -121,9 +122,9 @@ class ConfigManager:
     def _load(self) -> None:
 
         pm_cfg = ["boot"]
-        rc_cmds = ["init", "conf", "start", "enable_triggers", "disable_triggers", "prestop1", "prestop2", "stop", "scrap"]
+        self.rc_cmds = ["init", "conf", "start", "enable_triggers", "disable_triggers", "prestop1", "prestop2", "stop", "scrap"]
         cfgs = {}
-        for f in pm_cfg + rc_cmds:
+        for f in pm_cfg + self.rc_cmds:
             fpath = os.path.join(self.cfg_dir, f + ".json")
             if not os.path.exists(fpath):
                 raise RuntimeError(f"ERROR: {f}.json not found in {self.cfg_dir}")
@@ -143,7 +144,7 @@ class ConfigManager:
         for json_file in json_files:
             cmd = json_file.split(".")[0]
 
-            if cmd in rc_cmds+pm_cfg:
+            if cmd in self.rc_cmds+pm_cfg:
                 continue
 
             with open(os.path.join(self.cfg_dir,json_file), 'r') as jf:
@@ -154,7 +155,7 @@ class ConfigManager:
                 except json.decoder.JSONDecodeError as e:
                     raise RuntimeError(f"ERROR: failed to load {cmd}.json") from e
 
-        for c in rc_cmds+list(self.extra_cmds.keys()):
+        for c in self.rc_cmds+list(self.extra_cmds.keys()):
             self._import_cmd_data(c, cfgs[c])
 
         # Post-process conf
@@ -252,6 +253,33 @@ class ConfigManager:
                     c['uri'] = c['uri'].replace(str(port), str(newport))
                 self.log.debug(f"{c['uid']}: {c['uri']}")
 
+
+    def get_flat_dir(self) -> str:
+        import tempfile
+        import os
+        td = tempfile.TemporaryDirectory(
+            dir=os.getcwd(),
+            prefix='nanorc-flatconf-',
+        )
+        # data_path = os.path.join(td.name, 'data')
+        # os.mkdir(data_path)
+
+        import json
+        for app in self.boot["apps"]:
+            for cmd in self.rc_cmds:
+                with open(f'{os.path.join(td.name, app)}_{cmd}.json', 'w') as f:
+                    cmd_data = getattr(self, cmd)
+                    json.dump(cmd_data[app], f, indent=4, sort_keys=True)
+
+        self.conf_dirs.append(td)
+        return td.name
+
+    def __del__(self):
+        for td in self.conf_dirs:
+            td.cleanup()
+
+    def get_conf_location(self) -> str:
+        return self.get_flat_dir()
 
     def runtime_start(self, data: dict) -> dict:
         """

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -272,7 +272,7 @@ class ConfigManager:
                     json.dump(cmd_data[app], f, indent=4, sort_keys=True)
 
         self.conf_dirs.append(td)
-        return td.name
+        return "file://"+td.name
 
     def __del__(self):
         for td in self.conf_dirs:

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -121,7 +121,7 @@ class ConfigManager:
     def _load(self) -> None:
 
         pm_cfg = ["boot"]
-        rc_cmds = ["init", "conf", "start", "stop_trigger", "prestop1", "prestop2", "stop", "pause", "resume", "scrap"]
+        rc_cmds = ["init", "conf", "start", "enable_triggers", "disable_triggers", "prestop1", "prestop2", "stop", "scrap"]
         cfgs = {}
         for f in pm_cfg + rc_cmds:
             fpath = os.path.join(self.cfg_dir, f + ".json")

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -341,13 +341,10 @@ def start(ctx, obj:NanoContext, run_num:int, disable_data_storage:bool, trigger_
 @click.pass_obj
 @click.pass_context
 def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
-    prestop_sequence = [
-        "stop_trigger",
-        "prestop1",
-        "prestop2",
-    ]
 
-    for prestop in prestop_sequence:
+    for prestop in obj.rc.get_precommand_sequence('stop'):
+
+        obj.rc.console.print(f'Executing {prestop}')
         prestop_func = getattr(obj.rc, prestop, None)
         if not prestop_func:
             obj.rc.console.error(f"Prestop function {prestop} doesn't exist in nanorc.core, omitting!")

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -207,7 +207,7 @@ def add_start_trigger_parameters():
     def add_decorator(function):
         f1 = click.argument('run_num', type=int)(function)
         f2 = click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')(f1)
-j        f3 = click.option('--disable-data-storage/--enable-data-storage', type=bool, default=False, help='Toggle data storage')(f2)
+        f3 = click.option('--disable-data-storage/--enable-data-storage', type=bool, default=False, help='Toggle data storage')(f2)
         f4 = accept_wait()(f3)
         f5 = accept_timeout(None)(f4)
         return click.option('--message', type=str, default="")(f5)
@@ -228,7 +228,7 @@ def start_trigger(ctx, obj, **kwargs):
     kwargs['path'] = None
     wait = kwargs['wait']
     execute_cmd_sequence(
-        ctx = ctx,2
+        ctx = ctx,
         rc = obj.rc,
         command = 'start_run',
         force = False,

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -187,7 +187,7 @@ def cli(ctx, obj, traceback, loglevel, cfg_dumpdir, log_path, logbook_prefix, ti
 
     def cleanup_rc():
         if rc.topnode.state != 'none': logging.getLogger("cli").warning("NanoRC context cleanup: Terminating RC before exiting")
-        rc.terminate()
+        rc.terminate(force=True)
         if rc.return_code:
             ctx.exit(rc.return_code)
 

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -32,31 +32,18 @@ from rich.progress import *
 from nanorc.runmgr import SimpleRunNumberManager
 from nanorc.cfgsvr import FileConfigSaver
 from nanorc.core import NanoRC
+from nanorc.nano_context import NanoContext
 from nanorc.logbook import FileLogbook
 from nanorc.credmgr import credentials
 from nanorc.rest import RestApi, NanoWebContext, rc_context
 from nanorc.webui import WebServer
 import nanorc.argval as argval
-
-class NanoContext:
-    """docstring for NanoContext"""
-    def __init__(self, console: Console):
-        """Nanorc Context for click use.
-
-        Args:
-            console (Console): rich console for messages and logging
-        """
-        super(NanoContext, self).__init__()
-        self.console = console
-        self.print_traceback = False
-        self.rc = None
-
+from nanorc.common_commands import add_common_cmds, add_custom_cmds, accept_timeout, accept_wait, check_rc, execute_cmd_sequence
 
 # ------------------------------------------------------------------------------
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 # ------------------------------------------------------------------------------
-
 
 loglevels = {
     'CRITICAL': logging.CRITICAL,
@@ -83,43 +70,6 @@ def updateLogLevel(loglevel):
         for handler in sh_command_logger.handlers:
             handler.setLevel(sh_command_level)
 
-
-def accept_timeout(default_timeout):
-    def add_decorator(function):
-        return click.option('--timeout', type=int, default=default_timeout, help="Timeout, in seconds", callback=argval.validate_timeout)(function)
-    return add_decorator
-
-
-def check_rc(ctx, obj):
-    if not ctx.parent: return
-    if ctx.parent.invoked_subcommand == '*' and obj.rc.return_code:
-        ctx.exit(obj.rc.return_code)
-
-def add_custom_cmds(cli, rc_cmd_exec, cmds):
-    for c,d in cmds.items():
-        arg_list = {}
-        arg_default = {}
-        for app, app_data in d.items():
-            for modules_data in app_data.values():
-                for module_data in modules_data:
-                    module = module_data['match']
-                    cmd_data = module_data.get('data')
-                    if not cmd_data: continue
-                    for arg in cmd_data:
-                        arg_list[arg] = type(cmd_data[arg])
-                        arg_default[arg] = cmd_data[arg]
-
-        def execute_custom(ctx, obj, timeout, **kwargs):
-            rc_cmd_exec(command=obj.info_name, data=kwargs, timeout=timeout)
-
-        execute_custom = click.pass_obj(execute_custom)
-        execute_custom = click.pass_context(execute_custom)
-        execute_custom = click.command(c)(execute_custom)
-        execute_custom = accept_timeout(None)(execute_custom)
-        for arg, argtype in arg_list.items():
-            arg_pretty = arg.replace("_", "-")
-            execute_custom = click.option(f'--{arg_pretty}', type=argtype, default=arg_default[arg])(execute_custom)
-        cli.add_command(execute_custom, c)
 
 # ------------------------------------------------------------------------------
 @click_shell.shell(prompt='shonky rc> ', chain=True, context_settings=CONTEXT_SETTINGS)
@@ -177,6 +127,7 @@ def cli(ctx, obj, traceback, loglevel, cfg_dumpdir, log_path, logbook_prefix, ti
         if log_path:
             rc.log_path = os.path.abspath(log_path)
 
+        add_common_cmds(ctx.command)
         add_custom_cmds(ctx.command, rc.execute_custom_command, rc.custom_cmd)
 
         if web:
@@ -245,263 +196,77 @@ def cli(ctx, obj, traceback, loglevel, cfg_dumpdir, log_path, logbook_prefix, ti
         rest_thread.join()
         webui_thread.join()
 
-@cli.command('status')
-@click.pass_obj
-def status(obj: NanoContext):
-    obj.rc.status()
 
-@cli.command('pin-threads')
-@click.option('--pin-thread-file', type=click.Path(exists=True), default=None)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def pin_threads(ctx, obj:NanoContext, pin_thread_file, timeout:int):
-    data = { "script_name": 'thread_pinning' }
-    if pin_thread_file:
-        data["env"]: { "DUNEDAQ_THREAD_PIN_FILE": pin_thread_file }
-    obj.rc.execute_script(data=data, timeout=timeout)
 
-@cli.command('boot')
-@click.argument('partition', type=str, callback=argval.validate_partition)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def boot(ctx, obj, partition:str, timeout:int):
-    obj.rc.boot(partition=partition, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
+################################
+########### Commands ###########
+################################
 
-@cli.command('init')
-@click.option('--path', type=str, default=None, callback=argval.validate_node_path)
-@accept_timeout(None)
+def add_start_trigger_parameters():
+    # sigh start...
+    def add_decorator(function):
+        f1 = click.argument('run_num', type=int)(function)
+        f2 = click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')(f1)
+j        f3 = click.option('--disable-data-storage/--enable-data-storage', type=bool, default=False, help='Toggle data storage')(f2)
+        f4 = accept_wait()(f3)
+        f5 = accept_timeout(None)(f4)
+        return click.option('--message', type=str, default="")(f5)
+     # sigh end
+    return add_decorator
+
+
+def start_trigger_defaults_overwrite(kwargs):
+    kwargs['run_type'] = 'TEST'
+    return kwargs
+
+@cli.command('start_run')
+@add_start_trigger_parameters()
 @click.pass_obj
 @click.pass_context
-def init(ctx, obj, path, timeout:int):
-    obj.rc.init(path, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
+def start_trigger(ctx, obj, **kwargs):
+    obj.rc.run_num_mgr.set_run_number(kwargs['run_num'])
+    kwargs['path'] = None
+    wait = kwargs['wait']
+    execute_cmd_sequence(
+        ctx = ctx,2
+        rc = obj.rc,
+        command = 'start_run',
+        force = False,
+        **start_trigger_defaults_overwrite(kwargs)
+    )
 
-@cli.command('ls')
-@click.pass_obj
-def ls(obj):
-    obj.rc.ls()
 
-
-@cli.command('conf')
-@click.option('--path', type=str, default=None, callback=argval.validate_node_path)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def conf(ctx, obj, path, timeout:int):
-    obj.rc.conf(path, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
-
-@cli.command('message')
-@click.argument('message', type=str, default=None)
-@click.pass_obj
-def message(obj, message):
-    obj.rc.message(message)
-
-@cli.command('start')
-@click.argument('run_num', type=int)
-@click.option('--disable-data-storage/--enable-data-storage', type=bool, default=False, help='Toggle data storage')
-@click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
-@click.option('--resume-wait', type=int, default=0, help='Seconds to wait between Start and Resume commands')
-@click.option('--message', type=str, default="")
-@accept_timeout(None)
+@cli.command('go')
+@add_start_trigger_parameters()
 @click.pass_obj
 @click.pass_context
-def start(ctx, obj:NanoContext, run_num:int, disable_data_storage:bool, trigger_interval_ticks:int, resume_wait:int, message:str, timeout:int):
-    """
-    Start Command
+def go(ctx, obj, **kwargs):
+    obj.rc.run_num_mgr.set_run_number(kwargs['run_num'])
+    kwargs['path'] = None
+    wait = kwargs['wait']
+    execute_cmd_sequence(
+        ctx = ctx,
+        rc = obj.rc,
+        command = 'go',
+        force = False,
+        **start_trigger_defaults_overwrite(kwargs)
+    )
 
-    Args:
-        obj (NanoContext): Context object
-        run_num (int): Run number
-        disable_data_storage (bool): Flag to disable data writing to storage
-
-    """
-
-    obj.rc.run_num_mgr.set_run_number(run_num)
-    obj.rc.start(disable_data_storage, "TEST", message=message, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
-    time.sleep(resume_wait)
-    if obj.rc.return_code == 0:
-        time.sleep(resume_wait)
-        obj.rc.resume(trigger_interval_ticks, timeout=timeout)
-        obj.rc.status()
-
-@cli.command('stop')
-@click.option('--stop-wait', type=int, default=0, help='Seconds to wait between Pause and Stop commands')
-@click.option('--force', default=False, is_flag=True)
-@click.option('--message', type=str, default="")
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def stop(ctx, obj, stop_wait:int, force:bool, message:str, timeout:int):
-
-    for prestop in obj.rc.get_precommand_sequence('stop'):
-
-        obj.rc.console.print(f'Executing {prestop}')
-        prestop_func = getattr(obj.rc, prestop, None)
-        if not prestop_func:
-            obj.rc.console.error(f"Prestop function {prestop} doesn't exist in nanorc.core, omitting!")
-            continue
-        prestop_func(
-            force = force,
-            message = message,
-            timeout = timeout,
-            stop_sequence = True
-        )
-
-        check_rc(ctx,obj)
-        obj.rc.status()
-        time.sleep(stop_wait)
-
-        if obj.rc.return_code != 0 and not force:
-            break
-
-    if obj.rc.return_code == 0 or force:
-        obj.rc.stop(force, timeout=timeout)
-        obj.rc.status()
-
-@cli.command('pause')
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def pause(ctx, obj, timeout:int):
-    obj.rc.pause(timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
-
-@cli.command('resume')
-@click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def resume(ctx, obj:NanoContext, trigger_interval_ticks:int, timeout:int):
-    """Resume Command
-
-    Args:
-        obj (NanoContext): Context object
-        trigger_interval_ticks (int): Trigger separation in ticks
-    """
-    obj.rc.resume(trigger_interval_ticks, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
-
-
-@cli.command('scrap')
-@click.option('--path', type=str, default=None, callback=argval.validate_node_path)
-@click.option('--force', default=False, is_flag=True)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def scrap(ctx, obj, path, force, timeout):
-    obj.rc.scrap(path, force, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
 
 @cli.command('start_trigger')
-@click.option('--trigger-interval-ticks', type=int, default=None)
-@accept_timeout(None)
+@add_start_trigger_parameters()
 @click.pass_obj
 @click.pass_context
-def start_trigger(ctx, obj, trigger_interval_ticks, timeout):
-    obj.rc.start_trigger(trigger_interval_ticks, timeout=timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
-
-@cli.command('stop_trigger')
-@click.option('--force', default=False, is_flag=True)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def stop_trigger(ctx, obj, timeout, force):
-    obj.rc.stop_trigger(
-        timeout=timeout,
-        force=force,
-        stop_sequence=False
+def start_trigger(ctx, obj, timeout, **kwargs):
+    obj.rc.run_num_mgr.set_run_number(kwargs['run_num'])
+    kwargs['path'] = None
+    wait = kwargs['wait']
+    execute_cmd_sequence(
+        ctx = ctx,
+        rc = obj.rc,
+        command = 'start_trigger',
+        force = False,
+        **start_trigger_defaults_overwrite(kwargs)
     )
-    check_rc(ctx,obj)
-    obj.rc.status()
 
-@cli.command('change_rate')
-@click.argument('trigger-interval-ticks', type=int)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def change_rate(ctx, obj, trigger_interval_ticks, timeout):
-    obj.rc.change_rate(trigger_interval_ticks, timeout)
-    check_rc(ctx,obj)
-    obj.rc.status()
 
-@cli.command('enable')
-@click.argument('path', type=str, default=None, callback=argval.validate_node_path)
-@click.option('--resource-name', type=str, required=True)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def enable(ctx, obj, path, resource_name, timeout):
-    obj.rc.enable(path, timeout=timeout, resource_name=resource_name)
-    check_rc(ctx,obj)
-    obj.rc.status()
-
-@cli.command('disable')
-@click.argument('path', type=str, default=None, callback=argval.validate_node_path)
-@click.option('--resource-name', type=str, required=True)
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def disable(ctx, obj, path, resource_name, timeout):
-    obj.rc.disable(path, timeout=timeout, resource_name=resource_name)
-    check_rc(ctx,obj)
-    obj.rc.status()
-
-@cli.command('terminate')
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def terminate(ctx, obj, timeout):
-    obj.rc.terminate(timeout=timeout)
-    time.sleep(1)
-    obj.rc.status()
-
-@cli.command('expert_command')
-@click.argument('app', type=str, default=None, callback=argval.validate_node_path)
-@click.argument('json_file', type=click.Path(exists=True))
-@accept_timeout(None)
-@click.pass_obj
-def expert_command(obj, app, json_file, timeout):
-    obj.rc.send_expert_command(app, json_file, timeout=timeout)
-
-@cli.command('wait')
-@click.pass_obj
-@click.argument('seconds', type=int)
-def wait(obj, seconds):
-
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-        TimeRemainingColumn(),
-        TimeElapsedColumn(),
-        console=obj.console,
-    ) as progress:
-        waiting = progress.add_task("[yellow]waiting", total=seconds)
-
-        for _ in range(seconds):
-            progress.update(waiting, advance=1)
-
-            time.sleep(1)
-
-@cli.command('shell')
-@click.pass_obj
-@click.pass_context
-def start_shell(ctx, obj):
-    ctx.command = obj.shell
-    shell = make_click_shell(ctx,prompt=ctx.command.shell.prompt)
-    shell.cmdloop()

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -229,8 +229,9 @@ def start_defaults_overwrite(kwargs):
 @accept_wait()
 @click.pass_obj
 @click.pass_context
-def start_run(ctx, obj,wait:int, **kwargs):
+def start_run(ctx, obj, wait:int, **kwargs):
     obj.rc.run_num_mgr.set_run_number(kwargs['run_num'])
+    kwargs['node_path'] = None
     execute_cmd_sequence(
         ctx = ctx,
         rc = obj.rc,

--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -189,6 +189,7 @@ def shutdown(ctx, obj, wait:int, **kwargs):
 
 @click.command()
 @accept_wait()
+@accept_message()
 @add_run_end_parameters()
 @click.pass_obj
 @click.pass_context

--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -97,17 +97,6 @@ def ls_thread(ctx, obj):
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def init(ctx, obj, node_path, timeout:int):
-    obj.rc.init(node_path=node_path, timeout=timeout)
-    check_rc(ctx,obj.rc)
-    obj.rc.status()
-
-
-@click.command()
-@accept_path()
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
 def conf(ctx, obj, node_path, timeout:int):
     obj.rc.conf(node_path=node_path, timeout=timeout)
     check_rc(ctx,obj.rc)
@@ -313,7 +302,6 @@ def add_common_cmds(shell):
     shell.add_command(ls              , 'ls'              )
     shell.add_command(pin_threads     , 'pin_threads'     )
     shell.add_command(boot            , 'boot'            )
-    shell.add_command(init            , 'init'            )
     shell.add_command(conf            , 'conf'            )
     shell.add_command(enable_triggers , 'enable_triggers' )
     shell.add_command(disable_triggers, 'disable_triggers')

--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -63,12 +63,11 @@ def pin_threads(ctx, obj:NanoContext, pin_thread_file, timeout:int):
 
 
 @click.command()
-@click.argument('partition', type=str, callback=argval.validate_partition)
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def boot(ctx, obj, partition:str, timeout:int):
-    obj.rc.boot(partition=partition, timeout=timeout)
+def boot(ctx, obj, timeout:int):
+    obj.rc.boot(timeout=timeout)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 

--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -13,15 +13,18 @@ def accept_timeout(default_timeout):
         return click.option('--timeout', type=int, default=default_timeout, help="Timeout, in seconds", callback=argval.validate_timeout)(function)
     return add_decorator
 
-def accept_path():
+def accept_path(argument:bool=False):
     def add_decorator(function):
-        return click.option('--path', type=str, default=None, callback=argval.validate_node_path)(function)
+        if argument:
+            return click.argument('node-path', type=str, callback=argval.validate_node_path)(function)
+        else:
+            return click.option('--node-path', type=str, default=None, callback=argval.validate_node_path)(function)
     return add_decorator
 
 def accept_message(argument:bool=False):
     def add_decorator(function):
         if argument:
-            return click.argument('message', type=str, default="")(function)
+            return click.argument('message', type=str)(function)
         else:
             return click.option('--message', type=str, default="")(function)
     return add_decorator
@@ -29,6 +32,15 @@ def accept_message(argument:bool=False):
 def accept_wait():
     def add_decorator(function):
         return click.option('--wait', type=int, default=0, help="Seconds to wait between commands", callback=argval.validate_wait)(function)
+    return add_decorator
+
+def add_run_end_parameters():
+    # sigh start...
+    def add_decorator(function):
+        f1 = accept_timeout(None)(function)
+        f2 = click.option('--force', default=False, is_flag=True)(f1)
+        return click.option('--message', type=str, default="")(f2)
+     # sigh end
     return add_decorator
 
 @click.command()
@@ -45,9 +57,10 @@ def status(obj: NanoContext):
 
 
 @click.command()
+@click.option('--legend', type=bool, is_flag=True, default=False)
 @click.pass_obj
-def ls(obj):
-    obj.rc.ls()
+def ls(obj, legend):
+    obj.rc.ls(leg=legend)
 
 
 @click.command()
@@ -73,12 +86,19 @@ def boot(ctx, obj, timeout:int):
 
 
 @click.command()
+@click.pass_obj
+@click.pass_context
+def ls_thread(ctx, obj):
+    obj.rc.ls_thread()
+
+
+@click.command()
 @accept_path()
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def init(ctx, obj, path, timeout:int):
-    obj.rc.init(path, timeout=timeout)
+def init(ctx, obj, node_path, timeout:int):
+    obj.rc.init(node_path=node_path, timeout=timeout)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 
@@ -88,20 +108,11 @@ def init(ctx, obj, path, timeout:int):
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def conf(ctx, obj, path, timeout:int):
-    obj.rc.conf(path, timeout=timeout)
+def conf(ctx, obj, node_path, timeout:int):
+    obj.rc.conf(node_path=node_path, timeout=timeout)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 
-
-@click.command()
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
-def start(ctx, obj:NanoContext, timeout:int):
-    obj.rc.start(timeout=timeout)
-    check_rc(ctx,obj.rc)
-    obj.rc.status()
 
 @click.command()
 @click.option('--force', default=False, is_flag=True)
@@ -112,19 +123,57 @@ def disable_triggers(ctx, obj, timeout, force):
     obj.rc.disable_triggers(
         timeout=timeout,
         force=force,
-        stop_sequence=False
     )
     check_rc(ctx,obj.rc)
     obj.rc.status()
 
 @click.command()
-@accept_wait()
-@click.option('--force', default=False, is_flag=True)
-@accept_message(argument=False)
+@click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def terminate(ctx, obj, wait:int, timeout:int, message:str, force:bool):
+def enable_triggers(ctx, obj, **kwargs):
+    obj.rc.enable_triggers(**kwargs)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+@click.command()
+@add_run_end_parameters()
+@click.pass_obj
+@click.pass_context
+def prestop1(ctx, obj, **kwargs):
+    obj.rc.prestop1(**kwargs)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+@click.command()
+@accept_timeout(None)
+@click.option('--force', default=False, is_flag=True)
+@click.pass_obj
+@click.pass_context
+def prestop2(ctx, obj, **kwargs):
+    obj.rc.prestop2(**kwargs)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+@click.command()
+@accept_timeout(None)
+@click.option('--force', default=False, is_flag=True)
+@click.pass_obj
+@click.pass_context
+def stop(ctx, obj, **kwargs):
+    obj.rc.stop(**kwargs)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_wait()
+@click.option('--force', default=False, is_flag=True)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def terminate(ctx, obj, wait:int, timeout:int, force:bool):
     obj.rc.terminate(
         timeout=timeout,
         force=force,
@@ -135,44 +184,34 @@ def terminate(ctx, obj, wait:int, timeout:int, message:str, force:bool):
 
 @click.command()
 @accept_wait()
-@click.option('--force', default=False, is_flag=True)
-@accept_message(argument=False)
-@accept_timeout(None)
+@add_run_end_parameters()
 @click.pass_obj
 @click.pass_context
-def shutdown(ctx, obj, wait:int, timeout:int, message:str, force:bool):
+def shutdown(ctx, obj, wait:int, **kwargs):
+    kwargs['node_path'] = None
     execute_cmd_sequence(
         ctx = ctx,
         rc = obj.rc,
         wait = wait,
         command = 'shutdown',
-        force = force,
-        stop_sequence = True,
-        timeout = timeout,
-        message = message
+        force = kwargs['force'],
+        cmd_args = kwargs
     )
 
 @click.command()
 @accept_wait()
-@click.option('--force', default=False, is_flag=True)
-@accept_message(argument=False)
-@accept_timeout(None)
+@add_run_end_parameters()
 @click.pass_obj
 @click.pass_context
-def stop_run(ctx, obj, wait:int, force:bool, message:str, timeout:int):
+def stop_run(ctx, obj, wait:int, **kwargs):
     execute_cmd_sequence(
         ctx = ctx,
         rc = obj.rc,
-        path = None,
         command = 'stop_run',
-        force = force,
+        force = kwargs['force'],
         wait = wait,
-        stop_sequence = True,
-        message = message,
-        timeout = timeout,
+        cmd_args = kwargs
     )
-
-
 
 @click.command()
 @accept_path()
@@ -180,16 +219,12 @@ def stop_run(ctx, obj, wait:int, force:bool, message:str, timeout:int):
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def scrap(ctx, obj, path, force, timeout):
-    obj.rc.scrap(path, force, timeout=timeout)
+def scrap(ctx, obj, node_path, force, timeout):
+    obj.rc.scrap(node_path=node_path, force=force, timeout=timeout)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 
 
-@click.command()
-@accept_timeout(None)
-@click.pass_obj
-@click.pass_context
 @click.command()
 @click.argument('trigger-interval-ticks', type=int)
 @accept_timeout(None)
@@ -202,36 +237,44 @@ def change_rate(ctx, obj, trigger_interval_ticks, timeout):
 
 
 @click.command()
-@accept_path()
-@click.option('--resource-name', type=str, required=True)
+@accept_path(argument=True)
+@click.option('--resource-name', type=str, default=None)
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def include(ctx, obj, path, resource_name, timeout):
-    obj.rc.include(path, timeout=timeout, resource_name=resource_name)
+def include(ctx, obj, node_path, resource_name, timeout):
+    if not resource_name:
+        resource_name = node_path.name
+    obj.rc.include(node_path=node_path, timeout=timeout, resource_name=resource_name)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 
 
 @click.command()
-@accept_path()
-@click.option('--resource-name', type=str, required=True)
+@accept_path(argument=True)
+@click.option('--resource-name', type=str, default=None)
 @accept_timeout(None)
 @click.pass_obj
 @click.pass_context
-def exclude(ctx, obj, path, resource_name, timeout):
-    obj.rc.exclude(path, timeout=timeout, resource_name=resource_name)
+def exclude(ctx, obj, node_path, resource_name, timeout):
+    if not resource_name:
+        resource_name = node_path.name
+    obj.rc.exclude(node_path=node_path, timeout=timeout, resource_name=resource_name)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 
 
 @click.command()
-@click.argument('app', type=str, default=None, callback=argval.validate_node_path)
+@accept_path(argument=True)
 @click.argument('json_file', type=click.Path(exists=True))
 @accept_timeout(None)
 @click.pass_obj
-def expert_command(obj, app, json_file, timeout):
-    obj.rc.send_expert_command(app, json_file, timeout=timeout)
+def expert_command(obj, node_path, json_file, timeout):
+    obj.rc.send_expert_command(
+        node_path=node_path,
+        json_file=json_file,
+        timeout=timeout
+    )
 
 
 @click.command()
@@ -265,25 +308,29 @@ def start_shell(ctx, obj):
 
 
 def add_common_cmds(shell):
-    shell.add_command(message       , 'message'       )
-    shell.add_command(status        , 'status'        )
-    shell.add_command(ls            , 'ls'            )
-    shell.add_command(pin_threads   , 'pin_threads'   )
-    shell.add_command(boot          , 'boot'          )
-    shell.add_command(init          , 'init'          )
-    shell.add_command(conf          , 'conf'          )
-    shell.add_command(start         , 'start'         )
-    shell.add_command(stop_run      , 'stop_run'      )
-    shell.add_command(scrap         , 'scrap'         )
-    shell.add_command(terminate     , 'terminate'     )
-    shell.add_command(shutdown      , 'shutdown'      )
-    shell.add_command(change_rate   , 'change_rate'   )
-    shell.add_command(include       , 'include'       )
-    shell.add_command(exclude       , 'exclude'       )
-    shell.add_command(expert_command, 'expert_command')
-    shell.add_command(wait          , 'wait'          )
-    shell.add_command(start_shell   , 'start_shell'   )
-
+    shell.add_command(message         , 'message'         )
+    shell.add_command(status          , 'status'          )
+    shell.add_command(ls              , 'ls'              )
+    shell.add_command(pin_threads     , 'pin_threads'     )
+    shell.add_command(boot            , 'boot'            )
+    shell.add_command(init            , 'init'            )
+    shell.add_command(conf            , 'conf'            )
+    shell.add_command(enable_triggers , 'enable_triggers' )
+    shell.add_command(disable_triggers, 'disable_triggers')
+    shell.add_command(prestop1        , 'prestop1'        )
+    shell.add_command(prestop2        , 'prestop2'        )
+    shell.add_command(stop            , 'stop'            )
+    shell.add_command(stop_run        , 'stop_run'        )
+    shell.add_command(scrap           , 'scrap'           )
+    shell.add_command(terminate       , 'terminate'       )
+    shell.add_command(shutdown        , 'shutdown'        )
+    shell.add_command(change_rate     , 'change_rate'     )
+    shell.add_command(include         , 'include'         )
+    shell.add_command(exclude         , 'exclude'         )
+    shell.add_command(expert_command  , 'expert_command'  )
+    shell.add_command(wait            , 'wait'            )
+    shell.add_command(start_shell     , 'start_shell'     )
+    # shell.add_command(ls_thread       , 'ls_thread'       )
 
 def add_custom_cmds(cli, rc_cmd_exec, cmds):
     for c,d in cmds.items():
@@ -312,25 +359,28 @@ def add_custom_cmds(cli, rc_cmd_exec, cmds):
         cli.add_command(execute_custom, c)
 
 
-def execute_cmd_sequence(command:str, ctx, rc, wait:int, force:bool=False, skip_intermediate=False, **kwargs):
+def execute_cmd_sequence(command:str, ctx, rc, wait:int, force:bool, cmd_args:dict):
     sequence = rc.get_command_sequence(command)
     import time
 
     for seq_cmd in sequence:
-        if not rc.can_execute(seq_cmd, quiet=True):
-            if skip_intermediate:
+        cmd = seq_cmd['cmd']
+        optional = seq_cmd['optional']
+
+        if not rc.can_execute(cmd, quiet=True):
+            if optional:
                 continue
             elif not force:
-                rc.log.error(f"Cannot execute '{seq_cmd}' in the '{command}' sequence as the root node is '{rc.topnode.state}'!")
+                rc.log.error(f"Cannot execute '{cmd}' in the '{command}' sequence as the root node is '{rc.topnode.state}'!")
                 break
 
-        rc.console.print(f'Executing {seq_cmd}')
-        seq_func = getattr(rc, seq_cmd, None)
+        rc.console.rule(f'Executing \'{cmd}\'')
+        seq_func = getattr(rc, cmd, None)
         if not seq_func:
-            rc.log.error(f"Function {seq_cmd} doesn't exist in nanorc.core, omitting!")
+            rc.log.error(f"Function {cmd} doesn't exist in nanorc.core!")
             if not force: break
 
-        seq_func(**kwargs)
+        seq_func(**cmd_args)
 
         check_rc(ctx, rc)
         rc.status()

--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -1,0 +1,348 @@
+import nanorc.argval as argval
+from nanorc.nano_context import NanoContext
+import click
+
+def check_rc(ctx, rc):
+    if not ctx.parent: return
+    if ctx.parent.invoked_subcommand == '*' and rc.return_code:
+        ctx.exit(rc.return_code)
+
+
+def accept_timeout(default_timeout):
+    def add_decorator(function):
+        return click.option('--timeout', type=int, default=default_timeout, help="Timeout, in seconds", callback=argval.validate_timeout)(function)
+    return add_decorator
+
+def accept_path():
+    def add_decorator(function):
+        return click.option('--path', type=str, default=None, callback=argval.validate_node_path)(function)
+    return add_decorator
+
+def accept_message(argument:bool=False):
+    def add_decorator(function):
+        if argument:
+            return click.argument('message', type=str, default="")(function)
+        else:
+            return click.option('--message', type=str, default="")(function)
+    return add_decorator
+
+def accept_wait():
+    def add_decorator(function):
+        return click.option('--wait', type=int, default=0, help="Seconds to wait between commands", callback=argval.validate_wait)(function)
+    return add_decorator
+
+@click.command()
+@accept_message(argument=True)
+@click.pass_obj
+def message(obj, message):
+    obj.rc.message(message)
+
+
+@click.command()
+@click.pass_obj
+def status(obj: NanoContext):
+    obj.rc.status()
+
+
+@click.command()
+@click.pass_obj
+def ls(obj):
+    obj.rc.ls()
+
+
+@click.command()
+@click.option('--pin-thread-file', type=click.Path(exists=True), default=None)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def pin_threads(ctx, obj:NanoContext, pin_thread_file, timeout:int):
+    data = { "script_name": 'thread_pinning' }
+    if pin_thread_file:
+        data["env"]: { "DUNEDAQ_THREAD_PIN_FILE": pin_thread_file }
+    obj.rc.execute_script(data=data, timeout=timeout)
+
+
+@click.command()
+@click.argument('partition', type=str, callback=argval.validate_partition)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def boot(ctx, obj, partition:str, timeout:int):
+    obj.rc.boot(partition=partition, timeout=timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_path()
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def init(ctx, obj, path, timeout:int):
+    obj.rc.init(path, timeout=timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_path()
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def conf(ctx, obj, path, timeout:int):
+    obj.rc.conf(path, timeout=timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def start(ctx, obj:NanoContext, timeout:int):
+    obj.rc.start(timeout=timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+@click.command()
+@click.option('--force', default=False, is_flag=True)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def stop_trigger(ctx, obj, timeout, force):
+    obj.rc.stop_trigger(
+        timeout=timeout,
+        force=force,
+        stop_sequence=False
+    )
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+@click.command()
+@accept_wait()
+@click.option('--force', default=False, is_flag=True)
+@accept_message(argument=False)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def terminate(ctx, obj, wait:int, timeout:int, message:str, force:bool):
+    execute_cmd_sequence(
+        ctx = ctx,
+        rc = obj.rc,
+        command = 'terminate',
+        force = force,
+        wait = wait,
+        path = None,
+        message = message,
+        timeout = timeout,
+        skip_intermediate = True
+    )
+
+
+@click.command()
+@accept_wait()
+@click.option('--force', default=False, is_flag=True)
+@accept_message(argument=False)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def end_run(ctx, obj, wait:int, force:bool, message:str, timeout:int):
+    execute_cmd_sequence(
+        ctx = ctx,
+        rc = obj.rc,
+        path = None,
+        command = 'end_run',
+        force = force,
+        wait = wait,
+        stop_sequence = True,
+        message = message,
+        timeout = timeout,
+    )
+
+
+
+
+@click.command()
+@accept_path()
+@click.option('--force', default=False, is_flag=True)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def scrap(ctx, obj, path, force, timeout):
+    obj.rc.scrap(path, force, timeout=timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def pause(ctx, obj, timeout:int):
+    obj.rc.pause(timeout=timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@click.option('--trigger-interval-ticks', type=int, default=None, help='Trigger separation in ticks')
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def resume(ctx, obj, trigger_interval_ticks:int, timeout:int):
+    obj.rc.resume(trigger_interval_ticks, timeout=timeout)
+    check_rc(ctx,obj)
+    obj.rc.status()
+
+
+
+@click.command()
+@click.argument('trigger-interval-ticks', type=int)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def change_rate(ctx, obj, trigger_interval_ticks, timeout):
+    obj.rc.change_rate(trigger_interval_ticks, timeout)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_path()
+@click.option('--resource-name', type=str, required=True)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def enable(ctx, obj, path, resource_name, timeout):
+    obj.rc.enable(path, timeout=timeout, resource_name=resource_name)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@accept_path()
+@click.option('--resource-name', type=str, required=True)
+@accept_timeout(None)
+@click.pass_obj
+@click.pass_context
+def disable(ctx, obj, path, resource_name, timeout):
+    obj.rc.disable(path, timeout=timeout, resource_name=resource_name)
+    check_rc(ctx,obj.rc)
+    obj.rc.status()
+
+
+@click.command()
+@click.argument('app', type=str, default=None, callback=argval.validate_node_path)
+@click.argument('json_file', type=click.Path(exists=True))
+@accept_timeout(None)
+@click.pass_obj
+def expert_command(obj, app, json_file, timeout):
+    obj.rc.send_expert_command(app, json_file, timeout=timeout)
+
+
+@click.command()
+@click.pass_obj
+@click.argument('seconds', type=int)
+def wait(obj, seconds):
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeRemainingColumn(),
+        TimeElapsedColumn(),
+        console=obj.console,
+    ) as progress:
+        waiting = progress.add_task("[yellow]waiting", total=seconds)
+
+        for _ in range(seconds):
+            progress.update(waiting, advance=1)
+
+            time.sleep(1)
+
+
+@click.command()
+@click.pass_context
+def start_shell(ctx, obj):
+    ctx.command = obj.shell
+    shell = make_click_shell(ctx,prompt=ctx.command.shell.prompt)
+    shell.cmdloop()
+
+
+def add_common_cmds(shell):
+    shell.add_command(message       , 'message'       )
+    shell.add_command(status        , 'status'        )
+    shell.add_command(ls            , 'ls'            )
+    shell.add_command(pin_threads   , 'pin_threads'   )
+    shell.add_command(boot          , 'boot'          )
+    shell.add_command(init          , 'init'          )
+    shell.add_command(conf          , 'conf'          )
+    shell.add_command(start         , 'start'         )
+    shell.add_command(end_run       , 'end_run'       )
+    shell.add_command(scrap         , 'scrap'         )
+    shell.add_command(pause         , 'pause'         )
+    shell.add_command(resume        , 'resume'        )
+    shell.add_command(terminate     , 'terminate'     )
+    shell.add_command(change_rate   , 'change_rate'   )
+    shell.add_command(enable        , 'enable'        )
+    shell.add_command(disable       , 'disable'       )
+    shell.add_command(expert_command, 'expert_command')
+    shell.add_command(wait          , 'wait'          )
+    shell.add_command(start_shell   , 'start_shell'   )
+
+
+def add_custom_cmds(cli, rc_cmd_exec, cmds):
+    for c,d in cmds.items():
+        arg_list = {}
+        arg_default = {}
+        for app, app_data in d.items():
+            for modules_data in app_data.values():
+                for module_data in modules_data:
+                    module = module_data['match']
+                    cmd_data = module_data.get('data')
+                    if not cmd_data: continue
+                    for arg in cmd_data:
+                        arg_list[arg] = type(cmd_data[arg])
+                        arg_default[arg] = cmd_data[arg]
+
+        def execute_custom(ctx, obj, timeout, **kwargs):
+            rc_cmd_exec(command=obj.info_name, data=kwargs, timeout=timeout)
+
+        execute_custom = click.pass_obj(execute_custom)
+        execute_custom = click.pass_context(execute_custom)
+        execute_custom = click.command(c)(execute_custom)
+        execute_custom = accept_timeout(None)(execute_custom)
+        for arg, argtype in arg_list.items():
+            arg_pretty = arg.replace("_", "-")
+            execute_custom = click.option(f'--{arg_pretty}', type=argtype, default=arg_default[arg])(execute_custom)
+        cli.add_command(execute_custom, c)
+
+
+def execute_cmd_sequence(command:str, ctx, rc, wait:int, force:bool=False, skip_intermediate=False, **kwargs):
+    sequence = rc.get_command_sequence(command)
+    import time
+    
+    for seq_cmd in sequence:
+        if not rc.can_execute(seq_cmd, quiet=True):
+            if skip_intermediate:
+                continue
+            elif not force:
+                rc.log.error(f"Cannot execute '{seq_cmd}' in the '{command}' sequence as the root node is '{rc.topnode.state}'!")
+                break
+            
+        rc.console.print(f'Executing {seq_cmd}')
+        seq_func = getattr(rc, seq_cmd, None)
+        if not seq_func:
+            rc.log.error(f"Function {seq_cmd} doesn't exist in nanorc.core, omitting!")
+            if not force: break
+        
+        seq_func(**kwargs)
+
+        check_rc(ctx, rc)
+        rc.status()
+
+        if rc.return_code != 0 and not force:
+            break
+        
+        time.sleep(wait)

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -176,7 +176,7 @@ class NanoRC:
             return
 
         kwargs['timeout'] = kwargs['timeout'] if kwargs.get('timeout') else self.timeout
-        print(command, node_path.name)
+
         self.log.debug(f'Executing the cmd {command} on the node {node_path.name}, using timeout = {kwargs["timeout"]}')
         transition = getattr(node_path, command)
         kwargs['pm'] = self.pm
@@ -236,13 +236,7 @@ class NanoRC:
         """
         Abort applications
         """
-        self.execute_command("abort", timeout=timeout)
-
-    def init(self, node_path, timeout:int, **kwargs) -> NoReturn:
-        """
-        Initializes the applications.
-        """
-        self.execute_command("init", node_path=node_path, raise_on_fail=True, timeout=timeout)
+        self.execute_command("abort", timeout=timeout, force=True)
 
 
     def conf(self, node_path, timeout:int, **kwargs) -> NoReturn:

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -216,11 +216,11 @@ class NanoRC:
         )
 
 
-    def terminate(self, timeout:int=None, **kwargs) -> NoReturn:
+    def terminate(self, timeout:int=None, force:bool=False, **kwargs) -> NoReturn:
         """
         Terminates applications (but keep all the subsystems structure)
         """
-        self.execute_command("terminate", timeout=timeout, force=True)
+        self.execute_command("terminate", timeout=timeout, force=force)
 
 
     def init(self, path, timeout:int=None, **kwargs) -> NoReturn:

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -354,12 +354,6 @@ class NanoRC:
         """
         self.execute_command("stop", path=None, raise_on_fail=True, timeout=timeout, force=force)
 
-    def prestop1(self, force:bool=False, message:str="", timeout:int=None, stop_sequence:bool=True, **kwargs) -> NoReturn:
-        """
-        Sends stop command
-        """
-        self.execute_command("prestop1", path=None, raise_on_fail=True, timeout=timeout, force=force)
-
     def prestop2(self, force:bool=False, message:str="", timeout:int=None, stop_sequence:bool=True, **kwargs) -> NoReturn:
         """
         Sends stop command
@@ -401,21 +395,28 @@ class NanoRC:
     def execute_script(self, timeout, data=None) -> NoReturn:
         self.execute_custom_command('scripts', data=data, timeout=timeout)
 
-    # def start_trigger(self, trigger_interval_ticks: Union[int, None], timeout) -> NoReturn:
-    #     """
-    #     Start the triggers
-    #     """
-    #     self.execute_custom_command("start_trigger",
-    #                                 data={'trigger_interval_ticks':trigger_interval_ticks},
-    #                                 timeout=timeout)
+    def enable_triggers(self, trigger_interval_ticks: Union[int, None], timeout) -> NoReturn:
+        """
+        Start the triggers
+        """
+        self.execute_custom_command("enable_triggers",
+                                    data={'trigger_interval_ticks':trigger_interval_ticks},
+                                    timeout=timeout)
 
+    def disable_triggers(self, trigger_interval_ticks: Union[int, None], timeout) -> NoReturn:
+        """
+        Start the triggers
+        """
+        self.execute_custom_command("disable_triggers",
+                                    data={'trigger_interval_ticks':trigger_interval_ticks},
+                                    timeout=timeout)
 
-    def stop_trigger(self, timeout:int, force:bool=False, message:str="", stop_sequence:bool=True, **kwargs) -> NoReturn:
+    def prestop1(self, timeout:int, force:bool=False, message:str="", stop_sequence:bool=True, **kwargs) -> NoReturn:
         """
         Stop the triggers
         """
 
-        if not force and not self.topnode.can_execute("stop_trigger"):
+        if not force and not self.topnode.can_execute("disable_triggers"):
             self.return_code = self.topnode.return_code
             return
 
@@ -457,35 +458,35 @@ class NanoRC:
                                     timeout=timeout)
 
 
-    def disable(self, node, timeout, resource_name) -> NoReturn:
+    def exclude(self, node, timeout, resource_name) -> NoReturn:
         """
         Start the triggers
         """
 
-        if not node.can_execute_custom_or_expert("disable", False):
+        if not node.can_execute_custom_or_expert("exclude", False):
             self.return_code = node.return_code
             return
-        ret = node.disable()
+        ret = node.exclude()
         if ret != 0:
             return
-        self.execute_custom_command("disable",
+        self.execute_custom_command("exclude",
                                     data={'resource_name': resource_name if resource_name else node.name},
                                     timeout=timeout,
                                     node=node,
                                     check_dead=False)
 
 
-    def enable(self, node, timeout, resource_name) -> NoReturn:
+    def include(self, node, timeout, resource_name) -> NoReturn:
         """
         Start the triggers
         """
-        if not node.can_execute_custom_or_expert("enable", True):
+        if not node.can_execute_custom_or_expert("include", True):
             self.return_code = node.return_code
             return
-        ret = node.enable()
+        ret = node.include()
         if ret != 0:
             return
-        self.execute_custom_command("enable",
+        self.execute_custom_command("include",
                                     data={'resource_name': resource_name if resource_name else node.name},
                                     timeout=timeout,
                                     node=node)

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -317,7 +317,7 @@ class NanoRC:
 
             self.console.rule(f"[bold magenta]{text}[/bold magenta]")
         else:
-            self.log.error(f"[bold red]There was an error when starting the run #{run}[/bold red]:")
+            self.log.error(f"There was an error when starting the run #{run}:")
             self.log.error(f'Response: {self.topnode.response}')
 
     def message(self, message:str="") -> NoReturn:

--- a/src/nanorc/fsm.py
+++ b/src/nanorc/fsm.py
@@ -6,13 +6,13 @@ class FSM(Machine):
         if fsm_type == 'timing':
             self.states_cfg = [ 'none', 'booted', 'initialised', 'configured', 'error', 'running' ]
             self.transitions_cfg = [
-                { 'trigger': 'boot',      'source': 'none',        'dest': 'booted'     },
-                { 'trigger': 'init',      'source': 'booted',      'dest': 'initialised'},
-                { 'trigger': 'conf',      'source': 'initialised', 'dest': 'configured' },
+                { 'trigger': 'boot',      'source': 'none',        'dest': 'initial'    },
+                { 'trigger': 'conf',      'source': 'initial',     'dest': 'configured' },
                 { 'trigger': 'start',     'source': 'configured',  'dest': 'running'    },
                 { 'trigger': 'stop',      'source': 'running',     'dest': 'configured' },
                 { 'trigger': 'scrap',     'source': 'configured',  'dest': 'initialised'},
                 { 'trigger': 'terminate', 'source': 'initial',     'dest': 'none'       },
+                { 'trigger': 'terminate', 'source': 'error',       'dest': 'none'       },
                 { 'trigger': 'abort',     'source': '*',           'dest': 'none'       },
                 { 'trigger': 'to_error',  'source': '*',           'dest': 'error'      }
             ]
@@ -37,8 +37,7 @@ class FSM(Machine):
                 'paused', 'prestopped1', 'prestopped2', 'error'
             ]
             self.transitions_cfg = [
-                { 'trigger': 'boot',             'source': 'none',            'dest': 'booted'     },
-                { 'trigger': 'init',             'source': 'booted',          'dest': 'initial'    },
+                { 'trigger': 'boot',             'source': 'none',            'dest': 'initial'    },
                 { 'trigger': 'conf',             'source': 'initial',         'dest': 'configured' },
                 { 'trigger': 'start',            'source': 'configured',      'dest': 'ready'      },
                 { 'trigger': 'enable_triggers',  'source': 'ready',           'dest': 'running'    },
@@ -48,7 +47,6 @@ class FSM(Machine):
                 { 'trigger': 'stop',             'source': 'prestopped2',     'dest': 'configured' },
                 { 'trigger': 'scrap',            'source': 'configured',      'dest': 'initial'    },
                 { 'trigger': 'terminate',        'source': 'initial',         'dest': 'none'       },
-                { 'trigger': 'terminate',        'source': 'booted',          'dest': 'none'       },
                 { 'trigger': 'terminate',        'source': 'error',           'dest': 'none'       },
                 { 'trigger': 'abort',            'source': '*',               'dest': 'none'       },
                 { 'trigger': 'to_error',         'source': '*',               'dest': 'error'      }

--- a/src/nanorc/fsm.py
+++ b/src/nanorc/fsm.py
@@ -15,24 +15,34 @@ class FSM(Machine):
                 { "trigger": "terminate", "source": "*",           "dest": "none"       },
                 { "trigger": "to_error",  "source": "*",           "dest": "error"      }
             ]
+            self.precommand_sequence = { }
 
         else:
-            self.states_cfg = [ "none", "booted", "initialised", "configured", "running", "paused", "error"]
-            self.transitions_cfg = [
-                { "trigger": "boot",      "source": "none",        "dest": "booted"     },
-                { "trigger": "init",      "source": "booted",      "dest": "initialised"},
-                { "trigger": "conf",      "source": "initialised", "dest": "configured" },
-                { "trigger": "start",     "source": "configured",  "dest": "running"    },
-                { "trigger": "stop",      "source": "running" ,    "dest": "configured" },
-                { "trigger": "stop",      "source": "paused" ,     "dest": "configured" },
-                { "trigger": "resume",    "source": "running",     "dest": "running"    },
-                { "trigger": "resume",    "source": "paused",      "dest": "running"    },
-                { "trigger": "pause",     "source": "running",     "dest": "paused"     },
-                { "trigger": "pause",     "source": "paused",      "dest": "paused"     },
-                { "trigger": "scrap",     "source": "configured",  "dest": "initialised"},
-                { "trigger": "terminate", "source": "*",           "dest": "none"       },
-                { "trigger": "to_error",  "source": "*",           "dest": "error"      }
+            self.states_cfg = [
+                "none", "booted", "initialised", "configured", "running",
+                "paused", "trigger_stopped","prestopped1", "prestopped2", "error"
             ]
+            self.transitions_cfg = [
+                { "trigger": "boot",         "source": "none",            "dest": "booted"         },
+                { "trigger": "init",         "source": "booted",          "dest": "initialised"    },
+                { "trigger": "conf",         "source": "initialised",     "dest": "configured"     },
+                { "trigger": "start",        "source": "configured",      "dest": "running"        },
+                { "trigger": "stop_trigger", "source": "running",         "dest": "trigger_stopped"},
+                { "trigger": "prestop1",     "source": "trigger_stopped", "dest": "prestopped1"    },
+                { "trigger": "prestop2",     "source": "prestopped1",     "dest": "prestopped2"    },
+                { "trigger": "stop",         "source": "prestopped2",     "dest": "configured"     },
+                { "trigger": "resume",       "source": "running",         "dest": "running"        },
+                { "trigger": "resume",       "source": "paused",          "dest": "running"        },
+                { "trigger": "pause",        "source": "running",         "dest": "paused"         },
+                { "trigger": "pause",        "source": "paused",          "dest": "paused"         },
+                { "trigger": "scrap",        "source": "configured",      "dest": "initialised"    },
+                { "trigger": "terminate",    "source": "*",               "dest": "none"           },
+                { "trigger": "to_error",     "source": "*",               "dest": "error"          }
+            ]
+            self.precommand_sequence = {
+                "stop": ["stop_trigger", "prestop1", "prestop2"],
+            }
+
         if verbose:
             print_friendly_transitions = set()
             for tr in self.transitions_cfg:

--- a/src/nanorc/fsm.py
+++ b/src/nanorc/fsm.py
@@ -4,43 +4,46 @@ from functools import partial
 class FSM(Machine):
     def __init__(self,console, fsm_type, verbose=False):
         if fsm_type == 'timing':
-            self.states_cfg = [ "none", "booted", "initialised", "configured", "error", "running" ]
+            self.states_cfg = [ 'none', 'booted', 'initialised', 'configured', 'error', 'running' ]
             self.transitions_cfg = [
-                { "trigger": "boot",      "source": "none",        "dest": "booted"     },
-                { "trigger": "init",      "source": "booted",      "dest": "initialised"},
-                { "trigger": "conf",      "source": "initialised", "dest": "configured" },
-                { "trigger": "start",     "source": "configured",  "dest": "running"    },
-                { "trigger": "stop",      "source": "running",     "dest": "configured" },
-                { "trigger": "scrap",     "source": "configured",  "dest": "initialised"},
-                { "trigger": "terminate", "source": "*",           "dest": "none"       },
-                { "trigger": "to_error",  "source": "*",           "dest": "error"      }
+                { 'trigger': 'boot',      'source': 'none',        'dest': 'booted'     },
+                { 'trigger': 'init',      'source': 'booted',      'dest': 'initialised'},
+                { 'trigger': 'conf',      'source': 'initialised', 'dest': 'configured' },
+                { 'trigger': 'start',     'source': 'configured',  'dest': 'running'    },
+                { 'trigger': 'stop',      'source': 'running',     'dest': 'configured' },
+                { 'trigger': 'scrap',     'source': 'configured',  'dest': 'initialised'},
+                { 'trigger': 'terminate', 'source': '*',           'dest': 'none'       },
+                { 'trigger': 'to_error',  'source': '*',           'dest': 'error'      }
             ]
-            self.precommand_sequence = { }
+            self.command_sequences = { }
 
         else:
             self.states_cfg = [
-                "none", "booted", "initialised", "configured", "running",
-                "paused", "trigger_stopped","prestopped1", "prestopped2", "error"
+                'none', 'booted', 'initial', 'configured', 'ready', 'running',
+                'paused', 'prestopped1', 'prestopped2', 'error'
             ]
             self.transitions_cfg = [
-                { "trigger": "boot",         "source": "none",            "dest": "booted"         },
-                { "trigger": "init",         "source": "booted",          "dest": "initialised"    },
-                { "trigger": "conf",         "source": "initialised",     "dest": "configured"     },
-                { "trigger": "start",        "source": "configured",      "dest": "running"        },
-                { "trigger": "stop_trigger", "source": "running",         "dest": "trigger_stopped"},
-                { "trigger": "prestop1",     "source": "trigger_stopped", "dest": "prestopped1"    },
-                { "trigger": "prestop2",     "source": "prestopped1",     "dest": "prestopped2"    },
-                { "trigger": "stop",         "source": "prestopped2",     "dest": "configured"     },
-                { "trigger": "resume",       "source": "running",         "dest": "running"        },
-                { "trigger": "resume",       "source": "paused",          "dest": "running"        },
-                { "trigger": "pause",        "source": "running",         "dest": "paused"         },
-                { "trigger": "pause",        "source": "paused",          "dest": "paused"         },
-                { "trigger": "scrap",        "source": "configured",      "dest": "initialised"    },
-                { "trigger": "terminate",    "source": "*",               "dest": "none"           },
-                { "trigger": "to_error",     "source": "*",               "dest": "error"          }
+                { 'trigger': 'boot',         'source': 'none',            'dest': 'booted'         },
+                { 'trigger': 'init',         'source': 'booted',          'dest': 'initial'        },
+                { 'trigger': 'conf',         'source': 'initial',         'dest': 'configured'     },
+                { 'trigger': 'start',        'source': 'configured',      'dest': 'ready'          },
+                { 'trigger': 'start_trigger','source': 'ready',           'dest': 'running'        },
+                { 'trigger': 'pause',        'source': 'running',         'dest': 'paused'         },
+                { 'trigger': 'resume',       'source': 'paused',          'dest': 'running'        },
+                { 'trigger': 'stop_trigger', 'source': 'paused',          'dest': 'ready'          },
+                { 'trigger': 'stop_trigger', 'source': 'running',         'dest': 'ready'          },
+                { 'trigger': 'prestop1',     'source': 'ready',           'dest': 'prestopped1'    },
+                { 'trigger': 'prestop2',     'source': 'prestopped1',     'dest': 'prestopped2'    },
+                { 'trigger': 'stop',         'source': 'prestopped2',     'dest': 'configured'     },
+                { 'trigger': 'scrap',        'source': 'configured',      'dest': 'initial'        },
+                { 'trigger': 'terminate',    'source': '*',               'dest': 'none'           },
+                { 'trigger': 'to_error',     'source': '*',               'dest': 'error'          }
             ]
-            self.precommand_sequence = {
-                "stop": ["stop_trigger", "prestop1", "prestop2"],
+            self.command_sequences = {
+                'go'       : ['conf', 'start', 'start_trigger'],
+                'start_run': ['start', 'start_trigger'],
+                'end_run'  : ['stop_trigger', 'prestop1', 'prestop2', 'stop'],
+                'terminate': ['stop_trigger', 'prestop1', 'prestop2', 'stop', 'scrap', 'terminate'],
             }
 
         if verbose:

--- a/src/nanorc/fsm.py
+++ b/src/nanorc/fsm.py
@@ -12,10 +12,23 @@ class FSM(Machine):
                 { 'trigger': 'start',     'source': 'configured',  'dest': 'running'    },
                 { 'trigger': 'stop',      'source': 'running',     'dest': 'configured' },
                 { 'trigger': 'scrap',     'source': 'configured',  'dest': 'initialised'},
-                { 'trigger': 'terminate', 'source': '*',           'dest': 'none'       },
+                { 'trigger': 'terminate', 'source': 'initial',     'dest': 'none'       },
                 { 'trigger': 'to_error',  'source': '*',           'dest': 'error'      }
             ]
-            self.command_sequences = { }
+            self.command_sequences = {
+                'start_run': [
+                    {'cmd': 'configure', 'optional': True },
+                    {'cmd': 'start',     'optional': False},
+                ],
+                'stop_run' : [
+                    {'cmd': 'stop', 'optional': False},
+                ],
+                'shutdown' : [
+                    {'cmd': 'stop',      'optional': True },
+                    {'cmd': 'scrap',     'optional': True },
+                    {'cmd': 'terminate', 'optional': False},
+                ],
+            }
 
         else:
             self.states_cfg = [
@@ -23,27 +36,39 @@ class FSM(Machine):
                 'paused', 'prestopped1', 'prestopped2', 'error'
             ]
             self.transitions_cfg = [
-                { 'trigger': 'boot',         'source': 'none',            'dest': 'booted'         },
-                { 'trigger': 'init',         'source': 'booted',          'dest': 'initial'        },
-                { 'trigger': 'conf',         'source': 'initial',         'dest': 'configured'     },
-                { 'trigger': 'start',        'source': 'configured',      'dest': 'ready'          },
-                { 'trigger': 'start_trigger','source': 'ready',           'dest': 'running'        },
-                { 'trigger': 'pause',        'source': 'running',         'dest': 'paused'         },
-                { 'trigger': 'resume',       'source': 'paused',          'dest': 'running'        },
-                { 'trigger': 'stop_trigger', 'source': 'paused',          'dest': 'ready'          },
-                { 'trigger': 'stop_trigger', 'source': 'running',         'dest': 'ready'          },
-                { 'trigger': 'prestop1',     'source': 'ready',           'dest': 'prestopped1'    },
-                { 'trigger': 'prestop2',     'source': 'prestopped1',     'dest': 'prestopped2'    },
-                { 'trigger': 'stop',         'source': 'prestopped2',     'dest': 'configured'     },
-                { 'trigger': 'scrap',        'source': 'configured',      'dest': 'initial'        },
-                { 'trigger': 'terminate',    'source': '*',               'dest': 'none'           },
-                { 'trigger': 'to_error',     'source': '*',               'dest': 'error'          }
+                { 'trigger': 'boot',             'source': 'none',            'dest': 'booted'     },
+                { 'trigger': 'init',             'source': 'booted',          'dest': 'initial'    },
+                { 'trigger': 'conf',             'source': 'initial',         'dest': 'configured' },
+                { 'trigger': 'start',            'source': 'configured',      'dest': 'ready'      },
+                { 'trigger': 'enable_triggers',  'source': 'ready',           'dest': 'running'    },
+                { 'trigger': 'disable_triggers', 'source': 'running',         'dest': 'ready'      },
+                { 'trigger': 'prestop1',         'source': 'ready',           'dest': 'prestopped1'},
+                { 'trigger': 'prestop2',         'source': 'prestopped1',     'dest': 'prestopped2'},
+                { 'trigger': 'stop',             'source': 'prestopped2',     'dest': 'configured' },
+                { 'trigger': 'scrap',            'source': 'configured',      'dest': 'initial'    },
+                { 'trigger': 'terminate',        'source': 'initial',         'dest': 'none'       },
+                { 'trigger': 'to_error',         'source': '*',               'dest': 'error'      }
             ]
             self.command_sequences = {
-                'go'       : ['conf', 'start', 'start_trigger'],
-                'start_run': ['start', 'start_trigger'],
-                'end_run'  : ['stop_trigger', 'prestop1', 'prestop2', 'stop'],
-                'terminate': ['stop_trigger', 'prestop1', 'prestop2', 'stop', 'scrap', 'terminate'],
+                'start_run': [
+                    {'cmd': 'conf',            'optional': True },
+                    {'cmd': 'start',           'optional': False},
+                    {'cmd': 'enable_triggers', 'optional': False}
+                ],
+                'stop_run' : [
+                    {'cmd': 'disable_triggers', 'optional': True },
+                    {'cmd': 'prestop1',         'optional': False},
+                    {'cmd': 'prestop2',         'optional': False},
+                    {'cmd': 'stop',             'optional': False},
+                ],
+                'shutdown' : [
+                    {'cmd': 'disable_triggers', 'optional': True },
+                    {'cmd': 'prestop1',         'optional': True },
+                    {'cmd': 'prestop2',         'optional': True },
+                    {'cmd': 'stop',             'optional': True },
+                    {'cmd': 'scrap',            'optional': True },
+                    {'cmd': 'terminate',        'optional': False},
+                ],
             }
 
         if verbose:

--- a/src/nanorc/fsm.py
+++ b/src/nanorc/fsm.py
@@ -13,6 +13,7 @@ class FSM(Machine):
                 { 'trigger': 'stop',      'source': 'running',     'dest': 'configured' },
                 { 'trigger': 'scrap',     'source': 'configured',  'dest': 'initialised'},
                 { 'trigger': 'terminate', 'source': 'initial',     'dest': 'none'       },
+                { 'trigger': 'abort',     'source': '*',           'dest': 'none'       },
                 { 'trigger': 'to_error',  'source': '*',           'dest': 'error'      }
             ]
             self.command_sequences = {
@@ -47,6 +48,9 @@ class FSM(Machine):
                 { 'trigger': 'stop',             'source': 'prestopped2',     'dest': 'configured' },
                 { 'trigger': 'scrap',            'source': 'configured',      'dest': 'initial'    },
                 { 'trigger': 'terminate',        'source': 'initial',         'dest': 'none'       },
+                { 'trigger': 'terminate',        'source': 'booted',          'dest': 'none'       },
+                { 'trigger': 'terminate',        'source': 'error',           'dest': 'none'       },
+                { 'trigger': 'abort',            'source': '*',               'dest': 'none'       },
                 { 'trigger': 'to_error',         'source': '*',               'dest': 'error'      }
             ]
             self.command_sequences = {

--- a/src/nanorc/nano_context.py
+++ b/src/nanorc/nano_context.py
@@ -1,0 +1,14 @@
+from rich.console import Console
+
+class NanoContext:
+    """docstring for NanoContext"""
+    def __init__(self, console: Console):
+        """Nanorc Context for click use.
+
+        Args:
+            console (Console): rich console for messages and logging
+        """
+        super(NanoContext, self).__init__()
+        self.console = console
+        self.print_traceback = False
+        self.rc = None

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -187,8 +187,9 @@ class SubsystemNode(StatefulNode):
             boot_info['env']['DUNEDAQ_PARTITION'] = partition
 
             self.pm.boot(
-                boot_info=boot_info,
-                timeout=timeout
+                boot_info = boot_info,
+                timeout = timeout,
+                conf_loc = self.cfgmgr.get_conf_location()
             )
 
         except Exception as e:

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -357,7 +357,7 @@ class SubsystemNode(StatefulNode):
                     f=getattr(self.cfgmgr,cfg_method)
                     data = f(event.kwargs['overwrite_data'])
                 else:
-                    data = getattr(self.cfgmgr, command)
+                    data = {} # getattr(self.cfgmgr, command)
 
                 entry_state = child_node.state.upper()
                 if entry_state in appfwk_state_dictionnary: entry_state = appfwk_state_dictionnary[entry_state]
@@ -415,7 +415,7 @@ class SubsystemNode(StatefulNode):
                     f=getattr(self.cfgmgr,cfg_method)
                     data = f(event.kwargs['overwrite_data'])
                 else:
-                    data = getattr(self.cfgmgr, command)
+                    data = {}#getattr(self.cfgmgr, command)
 
                 kwargs = {'wait': False,
                           'cmd_data': data}

--- a/src/nanorc/node_render.py
+++ b/src/nanorc/node_render.py
@@ -82,8 +82,11 @@ def print_status(topnode, console, apparatus_id='', partition='') -> int:
             )
 
         else:
+            state_str = node.state
+            if not node.included:
+                state_str = Text(f"{node.state} - excluded")
             table.add_row(Text(pre)+Text(node.name),
-                          Text(f"{node.state}", style=('bold red' if node.is_error() else "")))
+                          Text(f"{state_str}", style=('bold red' if node.is_error() else "")))
 
     console.print(table)
 

--- a/src/nanorc/node_render.py
+++ b/src/nanorc/node_render.py
@@ -21,7 +21,7 @@ def status_data(node, get_children=True) -> dict:
         ret['ping'] = sup.commander.ping()
         ret['last_cmd_failed'] = (sup.last_sent_command != sup.last_ok_command)
         ret['name'] = node.name
-        ret['state'] = node.state + ("" if node.enabled else " - disabled")
+        ret['state'] = node.state + ("" if node.included else " - excluded")
         ret['host'] = sup.desc.host,
         ret['last_sent_command'] = sup.last_sent_command
         ret['last_ok_command'] = sup.last_ok_command

--- a/src/nanorc/node_render.py
+++ b/src/nanorc/node_render.py
@@ -65,8 +65,8 @@ def print_status(topnode, console, apparatus_id='', partition='') -> int:
             last_cmd_failed = (sup.last_sent_command != sup.last_ok_command)
 
             state_str = Text()
-            if not node.enabled:
-                state_str = Text(f"{node.state} - {alive} - disabled")
+            if not node.included:
+                state_str = Text(f"{node.state} - {alive} - excluded")
             elif node.is_error():
                 state_str = Text(f"{node.state} - {alive}", style=('bold red'))
             else:

--- a/src/nanorc/rest.py
+++ b/src/nanorc/rest.py
@@ -137,8 +137,8 @@ class command(Resource):
                 state_allowed_transitions += [transition['trigger']]
 
         if not state in ['none', "booted"]:
-            state_allowed_transitions += list(rc_context.rc.custom_cmd.keys()) + ["enable", "disable"]
-        if state in ['paused', "running"]:
+            state_allowed_transitions += list(rc_context.rc.custom_cmd.keys()) + ["include", "exclude"]
+        if state in ["running"]:
             state_allowed_transitions += ["start_trigger"+ "stop_trigger", "change_rate"]
         if state in ['configured', 'running']:
             state_allowed_transitions += ["pin-threads"]

--- a/src/nanorc/sshpm.py
+++ b/src/nanorc/sshpm.py
@@ -149,8 +149,8 @@ class SSHProcessManager(object):
             ssh_args = [host, "-tt", "-o StrictHostKeyChecking=no"] + [cmd]
             proc = sh.ssh(ssh_args)
             self.log.info(proc)
-            
-    def boot(self, boot_info, timeout):
+
+    def boot(self, boot_info, conf_loc, timeout):
 
         if self.apps:
             raise RuntimeError(
@@ -172,6 +172,7 @@ class SSHProcessManager(object):
                 "APP_NAME": app_name,
                 "APP_PORT": app_conf["port"],
                 "APP_WD": os.getcwd(),
+                "CONF_LOC": conf_loc,
             }
 
             exec_vars_cp = cp.deepcopy(boot_info['exec'][app_conf['exec']]['env'])

--- a/src/nanorc/sshpm.py
+++ b/src/nanorc/sshpm.py
@@ -322,6 +322,8 @@ class SSHProcessManager(object):
             if desc.proc is not None and desc.proc.is_alive():
                 try:
                     desc.proc.terminate()
+                    while desc.proc.is_alive():
+                        time.sleep(0.1)
                 except OSError:
                     pass
         self.apps = {}

--- a/src/nanorc/statefulnode.py
+++ b/src/nanorc/statefulnode.py
@@ -78,13 +78,23 @@ class StatefulNode(NodeMixin):
         if not self.included:
             self.log.error(f'Cannot exclude \'{self.name}\' as it is already excluded!')
             return 1
+
+        ret = 0
+        for child in self.children:
+            ret += child.exclude()
+
         self.included = False
-        return 0
+        return ret
 
     def include(self):
         if self.included:
             self.log.error(f'Cannot include \'{self.name}\' as it is already included!')
             return 1
+
+        ret = 0
+        for child in self.children:
+            ret += child.include()
+
         self.included = True
         return 0
 
@@ -105,8 +115,15 @@ class StatefulNode(NodeMixin):
     def on_enter_terminate_ing(self, _) -> NoReturn:
         if self.children:
             for child in self.children:
-                child.terminate()
+                if child.included:
+                    child.terminate()
         self.end_terminate()
+
+    def on_enter_abort_ing(self, _) -> NoReturn:
+        if self.children:
+            for child in self.children:
+                child.abort()
+        self.end_abort()
 
 
     def on_enter_error(self, event):

--- a/src/nanorc/statefulnode.py
+++ b/src/nanorc/statefulnode.py
@@ -38,7 +38,7 @@ class StatefulNode(NodeMixin):
     def can_execute_custom_or_expert(self, command, check_dead=True):
         disallowed_state = ['booted', 'none']
         if self.state in disallowed_state:
-            self.log.error(f"Cannot send {command} to {self.name} as it should at least be initialised")
+            self.log.error(f"Cannot send '{command}' to '{self.name}' as it should at least be initialised")
             return False
 
         for c in self.children:
@@ -52,14 +52,15 @@ class StatefulNode(NodeMixin):
         return True
 
 
-    def can_execute(self, command):
+    def can_execute(self, command, quiet=False):
         can_transition = getattr(self, "can_"+command)
         if not can_transition:
-            self.log.info(f"{self.name} cannot check if command {command} is possible")
+            self.log.info(f"'{self.name}' cannot check if command '{command}' is possible")
         else:
             if not can_transition():
-                self.log.error(f"{self.name} cannot {command} as it is {self.state}")
-                self.return_code = ErrorCode.InvalidTransition
+                if not quiet:
+                    self.log.error(f"'{self.name}' cannot '{command}' as it is '{self.state}'")
+                    self.return_code = ErrorCode.InvalidTransition
                 return False
 
         for c in self.children:
@@ -75,14 +76,14 @@ class StatefulNode(NodeMixin):
 
     def disable(self):
         if not self.enabled:
-            self.log.error(f'Cannot disable {self.name} as it is already disabled!')
+            self.log.error(f'Cannot disable \'{self.name}\' as it is already disabled!')
             return 1
         self.enabled = False
         return 0
 
     def enable(self):
         if self.enabled:
-            self.log.error(f'Cannot enable {self.name} as it is already enabled!')
+            self.log.error(f'Cannot enable \'{self.name}\' as it is already enabled!')
             return 1
         self.enabled = True
         return 0
@@ -125,12 +126,12 @@ class StatefulNode(NodeMixin):
 
         if event.kwargs.get("ssh_exit_code"): ssh_exit_code = f", the following error code was sent from ssh: {event.kwargs['ssh_exit_code']}"
 
-        self.log.error(f"while trying to \"{command}\" \"{self.name}\""+etext+ssh_exit_code)
+        self.log.error(f"while trying to '{command}' '{self.name}'"+etext+ssh_exit_code)
 
 
     def _on_enter_callback(self, event):
         command = event.event.name
-        self.log.info(f"{self.name} received command '{command}'")
+        self.log.info(f"'{self.name}' received command '{command}'")
         source_state = event.transition.source
         force = event.kwargs.get('force')
 


### PR DESCRIPTION
This PR uses https://github.com/DUNE-DAQ/daqconf/pull/120 and feeds:
 - `stop_trigger`
 - `prestop1`
 - `prestop2`.
to the apps before `stop`.

Specifically, the changes are:
 - Addition of the FSM corresponding to this commands (`trigger_stopped`, `prestopped1`, and `prestopped2`).
 - Issuing `stop` now execute these 4: stop_trigger, prestop1, prestop2, stop. Note that `pause` isn't here!!
 - If the `--force` parameter isn't `True`, the sequence stop after any of the command fails
 - The run registry stop message is done at the `stop_trigger` command (i.e. the run stops at stop_trigger).
 - `stop_trigger` can also be executed without wanting to stop, in which case the run doesn't stop.