### PR TITLE
Fix overwritten kerberos tickets

### DIFF
--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -221,7 +221,7 @@ def start_defaults_overwrite(kwargs):
     return kwargs
 
 def is_authenticated():
-    if not credentials.check_kerberos_credentials():
+    if not credentials.check_kerberos_credentials(silent=True):
         logging.getLogger("cli").error(f'\'{credentials.user}\' doesn\'t have valid kerberos ticket, use \'kinit\', or \'change_user\' to create a ticket (in a shell or in nanorc)')
         return False
     return True

--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -192,6 +192,19 @@ def change_user(ctx, obj, user):
 def kinit(ctx, obj):
     credentials.new_kerberos_ticket()
 
+@np04cli.command('klist')
+@click.pass_obj
+@click.pass_context
+def klist(ctx, obj):
+    credentials.check_kerberos_credentials(silent=False)
+    import subprocess
+    # print(subprocess.call(['klist', '-s']))
+    proc = subprocess.run(['klist', '-s'], capture_output=True, text=True, env=credentials.krbenv)
+    obj.rc.log.info(f'klist -s\nstdout: {proc.stdout}')
+    obj.rc.log.info(f'stderr: {proc.stderr}')
+    obj.rc.log.info(f'ret code: {proc.returncode}')
+
+
 def add_run_start_parameters():
     # sigh start...
     def add_decorator(function):

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -12,12 +12,11 @@ from .statefulnode import StatefulNode, CanExecuteReturnVal
 from .treebuilder import TreeBuilder
 from .cfgsvr import FileConfigSaver, DBConfigSaver
 from .credmgr import credentials
-from .node_render import *
+from .node_render import print_node, print_status
 from .logbook import ElisaLogbook, FileLogbook
 import importlib
 from . import confdata
 from rich.traceback import Traceback
-from rich.progress import *
 from rich.table import Table
 from .runinfo import start_run, print_run_info
 

--- a/src/nanorc/credmgr.py
+++ b/src/nanorc/credmgr.py
@@ -32,18 +32,18 @@ class CredentialManager:
         #     shutil.rmtree(self.krb_cache_path)
 
     def create_kerb_cache(self):
-        if self.partition_number is None:
-            raise RuntimeError('Partition number hasn\'t been specified, I cannot create a nanorc kerberos cache')
+        if self.partition_number is None or self.partition_name is None:
+            raise RuntimeError('Partition number (or name) hasn\'t been specified, I cannot create a nanorc kerberos cache')
 
-        self.krb_cache_path = Path(os.path.expanduser(f'~/.nanorc_kerbcache_part{self.partition_number}'))
+        self.krb_cache_path = Path(os.path.expanduser(f'~/.nanorc_kerbcache_{self.partition_name}_part{self.partition_number}'))
         if not os.path.isdir(self.krb_cache_path):
             os.mkdir(self.krb_cache_path)
         self.krbenv = {'KRB5CCNAME': f'DIR:{self.krb_cache_path}'}
         self.cache_initialised = True
 
-    def set_partition(self, partition_number, partition_name):
+    def set_partition(self, partition_number, apparatus_id):
         self.partition_number = partition_number
-        self.partition_name = partition_name
+        self.partition_name = apparatus_id # here is the mother of all the partition definition questions...
         self.create_kerb_cache()
 
     def stop_partition(self):

--- a/src/nanorc/credmgr.py
+++ b/src/nanorc/credmgr.py
@@ -47,12 +47,12 @@ class CredentialManager:
         self.create_kerb_cache()
 
     def stop_partition(self):
-        if os.path.isfile(self.krb_cache_path/'active'):
-            os.remove(self.krb_cache_path/'active')
+        if os.path.isfile(self.krb_cache_path/'active_partition'):
+            os.remove(self.krb_cache_path/'active_partition')
 
     def start_partition(self):
         if not self.cache_initialised: raise RuntimeError('Nanorc\'s kerberos cache wasn\'t initialised!')
-        f = open(self.krb_cache_path/'active', "w")
+        f = open(self.krb_cache_path/'active_partition', "w")
         f.write(self.partition_name)
         f.close()
 
@@ -106,8 +106,8 @@ class CredentialManager:
 
     def partition_in_use(self):
         if not self.cache_initialised: raise RuntimeError('Nanorc\'s kerberos cache wasn\'t initialised!')
-        if os.path.isfile(self.krb_cache_path/'active'):
-            f = open(self.krb_cache_path/'active', "r")
+        if os.path.isfile(self.krb_cache_path/'active_partition'):
+            f = open(self.krb_cache_path/'active_partition', "r")
             pname = f.read()
             return pname
         return None


### PR DESCRIPTION
This PR should fix a long standing issue which people running the DAQ at NP04 had. The problem is that `nanorc` uses the "standard" path to store its kerberos tickets, so everytime another user logs in, he/she forwards his/her ticket and since nanorc checks that the username is the same as the one in the ticket, it asks you to log in again.
This is fixed by creating a directory in `~/.nanorc_kerbcache` where nanorc stores all the ticket, that doesn't get overwritten.