### PR TITLE
check FSM error first, THEN for error/force flag

### DIFF
--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -362,7 +362,7 @@ def execute_cmd_sequence(command:str, ctx, rc, wait:int, force:bool, cmd_args:di
     for seq_cmd in sequence:
         cmd = seq_cmd['cmd']
         optional = seq_cmd['optional']
-        canexec = rc.can_execute(cmd, quiet=True, check_children=False)
+        canexec = rc.can_execute(cmd, quiet=True, check_children=False, check_inerror=False)
         
         if canexec == CanExecuteReturnVal.InvalidTransition:
             if optional:


### PR DESCRIPTION
This fixes the problem that happens when the top node is in error, and `shutdown --force` is issued, it will try to `drain-dataflow` first, which shouldn't happen. The fix in this PR is that sequential command function firstly checks that the command it's trying to execute is valid under the rules of the FSM (irrespective of its error state), and AFTER THAT, checks if the node is in error state and force execute the command if needed.