### PR TITLE
add a timeout for the commands

### DIFF
--- a/src/nanorc/appctrl.py
+++ b/src/nanorc/appctrl.py
@@ -269,6 +269,7 @@ class AppCommander:
             self.app_url,
             data=json.dumps(cmd),
             headers=headers,
+            timeout=1.,
             proxies={
                 'http': f'socks5h://{self.proxy[0]}:{self.proxy[1]}',
                 'https': f'socks5h://{self.proxy[0]}:{self.proxy[1]}'


### PR DESCRIPTION
Creating this pull request. Was run in EHN1 during integration week to make sure pings to login to servers respected timeouts.