### PR TITLE
Print the host:port of apps found to be "already running"

### DIFF
--- a/src/nanorc/sshpm.py
+++ b/src/nanorc/sshpm.py
@@ -275,7 +275,7 @@ class SSHProcessManager(object):
         apps_running = []
         for name, desc in self.apps.items():
             if is_port_open(desc.host, desc.port):
-                apps_running += [name]
+                apps_running += [f"{name} ({desc.host}:{desc.port})"]
         if apps_running:
             raise RuntimeError(f"ERROR: apps already running? {apps_running}")
 


### PR DESCRIPTION
, in case the names do not match (as seen in listrev_test, where the first app changes names but always is at localhost:3333).