### PR TITLE
NanoRC conf svc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ rich==10.14.0
 sh==1.14.1
 graphviz==0.16
 anytree==2.8.0
+deepdiff==6.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ console_scripts =
     nano-drawconf = nanorc.tools.drawconf:main
     get-run-conf = nanorc.tools.get_run_conf:main
     upload-conf = nanorc.tools.upload_conf:main
+    nano-conf-svc = nanorc.tools.nano_conf_svc:main

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "PySocks",
         "anytree",
         "transitions",
+        "deepdiff",
     ],
     extras_require={"develop": [
         "ipdb",

--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -189,6 +189,7 @@ def np04cli(ctx, obj, traceback, loglevel, elisa_conf, log_path, cfg_dumpdir, do
         raise click.Abort()
 
     def cleanup_rc():
+        rc.quit()
         credentials.quit()
         if rc.topnode.state != 'none':
             logging.getLogger("cli").warning("NanoRC context cleanup: Aborting applications before exiting")
@@ -210,7 +211,7 @@ def np04cli(ctx, obj, traceback, loglevel, elisa_conf, log_path, cfg_dumpdir, do
         tui = NanoRCTUI(host=host, rest_port=rest_port, timeout=rc.timeout, banner=Panel.fit(grid))
         tui.run()
         cleanup_rc()
-        ctx.exit(rc.return_code) 
+        ctx.exit(rc.return_code)
 
 @np04cli.command('change_user')
 @click.argument('user', type=str, default=None)

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -141,6 +141,7 @@ def timingcli(ctx, obj, traceback, pm, loglevel, log_path, cfg_dumpdir, kerberos
         raise click.Abort()
 
     def cleanup_rc():
+        rc.quit()
         if rc.topnode.state != 'none': logging.getLogger("cli").warning("NanoRC context cleanup: Terminating RC before exiting")
         rc.abort(timeout=120)
         if rc.return_code:
@@ -154,7 +155,7 @@ def timingcli(ctx, obj, traceback, pm, loglevel, log_path, cfg_dumpdir, kerberos
     if web:
         rest_thread.join()
         webui_thread.join()
-    
+
     if tui:
         from .tui import NanoRCTUI
         tui = NanoRCTUI(host=host, rest_port=rest_port, timeout=rc.timeout, banner=Panel.fit(grid))

--- a/src/nanorc/argval.py
+++ b/src/nanorc/argval.py
@@ -56,6 +56,15 @@ def validate_partition_number(ctx, param, number):
         raise click.BadParameter(f"Partition number should be between 0 and 10 (you fed {number})")
     return number
 
+def validate_conf_name(ctx, param, conf_name):
+    import re
+
+    pat = re.compile(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?')
+    ## Nanorc-12334 allowed (with hyphen) This is straight from k8s error message when the partition name isn't right
+    if not re.fullmatch(pat, conf_name):
+        raise click.BadParameter(f'Name {conf_name} should be alpha-numeric-hyphen! Make sure you name has the form [a-z0-9]([-a-z0-9]*[a-z0-9])?')
+    return conf_name
+
 def validate_partition(ctx, param, partition):
     pat = re.compile(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?') ## Nanorc-12334 allowed (with hyphen) This is straight from k8s error message when the partition name isn't right
     if not re.fullmatch(pat, partition):
@@ -79,7 +88,7 @@ def validate_conf(ctx, param, top_cfg):
     if confurl.scheme == 'db':
         return confurl
 
-    raise click.BadParameter(f"TOP_CFG should either be a directory, a json file, or a config service utility with the form db://the_conf_name?1 (where the ?1 at the end is optional and represents the version). You provided: '{top_cfg}'")
+    raise click.BadParameter(f"Could not find the configuration \'{top_cfg}\' (or this configuration does not have the correct format)")
 
 
 

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -79,7 +79,10 @@ class ConfigManager:
         attributes_for_k8s = [
             'boot.exec.daq_application_k8s',
         ]
-        attributes_for_ssh = []
+        attributes_for_ssh = [
+            'boot.hosts-ctrl',
+            'boot.hosts-data'
+        ]
 
         def key_present(key, jsond):
             keys = key.split('.')

--- a/src/nanorc/cfgmgr.py
+++ b/src/nanorc/cfgmgr.py
@@ -86,17 +86,13 @@ class ConfigManager:
 
         def key_present(key, jsond):
             keys = key.split('.')
-            print(keys)
-            print(jsond.keys())
             primary = keys[0]
 
             if len(keys) == 1:
                 ret = primary in jsond
-                print(f'keys == 1 {ret}')
                 return ret
 
             rest = '.'.join(keys[1:])
-            print(f'prim: {primary}, rest: {rest}')
             if primary in jsond:
                 return key_present(rest, jsond[primary])
             return False

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -198,6 +198,7 @@ def cli(ctx, obj, traceback, loglevel, cfg_dumpdir, log_path, logbook_prefix, ti
         raise click.Abort()
 
     def cleanup_rc():
+        rc.quit()
         if rc.topnode.state != 'none':
             logging.getLogger("cli").warning("NanoRC context cleanup: Aborting applications before exiting")
             rc.abort(timeout=120)

--- a/src/nanorc/confserver.py
+++ b/src/nanorc/confserver.py
@@ -1,0 +1,108 @@
+import logging
+from rich.console import Console
+from flask_restful import Resource
+from flask import request, abort, make_response, jsonify
+
+
+'''
+Resources for Flask app
+'''
+
+class RetrieveConf(Resource):
+    def get(self):
+        log = logging.getLogger('RetrieveConf')
+        log.debug(f'GET "RetrieveConf" request with args: {request.args}')
+        name = request.args.get('name')
+
+        if not name:
+            abort(404, description=f'You need to provide a configuration name!')
+
+        log.debug(f"Looking for config {name}")
+
+        if name not in self.conf_data:
+            abort(404, description=f'Couldn\'t find the configuration \"{name}\", available configurations are {list(self.conf_data.keys())}')
+
+        return make_response(jsonify(self.conf_data[name]))
+
+    @classmethod
+    def set_conf_data(cls, conf_data):
+        cls.conf_data = conf_data
+        return cls
+
+class ListConf(Resource):
+    def get(self):
+        log = logging.getLogger('ListConf')
+        log.info(f'GET "RetrieveConf" request')
+        return make_response(jsonify(list(self.conf_data.keys())))
+
+    @classmethod
+    def set_conf_data(cls, conf_data):
+        cls.conf_data = conf_data
+        return cls
+
+class ConfServer:
+    def __init__(self, name_to_paths_map={}):
+        self.log = logging.getLogger('nano-conf-service')
+
+        self.conf_data = {}
+        from nanorc.argval import validate_conf_name
+        from pathlib import Path
+        for name, path in name_to_paths_map.items():
+            validate_conf_name({}, {}, name)
+            self.conf_data[name] = self.get_json_recursive(Path(path))
+
+
+    def get_json_recursive(self, path):
+        import json, os
+
+        data = {}
+        boot = path/"boot.json"
+        if os.path.isfile(boot):
+            with open(boot,'r') as f:
+                data['boot'] = json.load(f)
+
+        for filename in os.listdir(path):
+            if os.path.isfile(path/filename) and filename[-5:] == ".info":
+                with open(path/filename,'r') as f:
+                    data['config_info'] = json.load(f)
+
+        for filename in os.listdir(path/"data"):
+            with open(path/'data'/filename,'r') as f:
+                app_cmd = filename.replace('.json', '').split('_')
+                app = app_cmd[0]
+                cmd = "_".join(app_cmd[1:])
+
+                if not app in data:
+                    data[app] = {
+                        cmd: json.load(f)
+                    }
+                else:
+                    data[app][cmd]=json.load(f)
+
+        return data
+
+    def start_conf_service(self, port):
+        from flask import Flask
+        from flask_restful import Api
+
+        self.app = Flask('nano-conf-svc')
+        self.api = Api(self.app)
+
+        RetrieveConf_withdata = RetrieveConf.set_conf_data(self.conf_data)
+        ListConf_withdata     = ListConf.set_conf_data(self.conf_data)
+
+        self.api.add_resource(RetrieveConf_withdata, "/retrieveLast", methods=['GET'])
+        self.api.add_resource(ListConf_withdata    , "/"    , methods=['GET'])
+        #self.api.add_resource(ListConf_withdata    , "/"            , methods=['GET'])
+
+        from .utils import FlaskManager
+        self.manager = FlaskManager(
+            port = port,
+            app = self.app,
+            name = "nano-conf-svc"
+        )
+
+        self.manager.start()
+
+    def terminate(self):
+        self.manager.stop()

--- a/src/nanorc/confserver.py
+++ b/src/nanorc/confserver.py
@@ -3,83 +3,42 @@ from rich.console import Console
 from flask_restful import Resource
 from flask import request, abort, make_response, jsonify
 
+class ConfigurationEndpoint(Resource):
+    def __init__(self, config_data, *args, **kwargs):
+        self.conf_data = config_data
+        super().__init__(*args, **kwargs)
+        self.log = logging.getLogger('ConfigurationEndpoint')
 
-'''
-Resources for Flask app
-'''
+    def post(self):
+        self.log.debug(f'POST "ConfigurationEndpoint" request with args: {request.args}')
+        res = {}
+        try:
+            name = request.args['name']
+            conf_json = request.json
+            self.conf_data[name] = conf_json
+            res['success'] = True
+        except Exception as e:
+            res['error'] = str(e)
+            res['success'] = False
+        return make_response(jsonify(res))
 
-class RetrieveConf(Resource):
     def get(self):
-        log = logging.getLogger('RetrieveConf')
-        log.debug(f'GET "RetrieveConf" request with args: {request.args}')
+        self.log.debug(f'GET "ConfigurationEndpoint" request with args: {request.args}')
         name = request.args.get('name')
 
         if not name:
-            abort(404, description=f'You need to provide a configuration name!')
+            return make_response(jsonify(list(self.conf_data.keys())))
 
-        log.debug(f"Looking for config {name}")
-
+        self.log.debug(f"Looking for config {name}")
         if name not in self.conf_data:
-            abort(404, description=f'Couldn\'t find the configuration \"{name}\", available configurations are {list(self.conf_data.keys())}')
+            abort(404, description=f'{name} not in configurations store, available configs are: {list(self.conf_data.keys())}')
 
-        return make_response(jsonify(self.conf_data[name]))
-
-    @classmethod
-    def set_conf_data(cls, conf_data):
-        cls.conf_data = conf_data
-        return cls
-
-class ListConf(Resource):
-    def get(self):
-        log = logging.getLogger('ListConf')
-        log.info(f'GET "RetrieveConf" request')
-        return make_response(jsonify(list(self.conf_data.keys())))
-
-    @classmethod
-    def set_conf_data(cls, conf_data):
-        cls.conf_data = conf_data
-        return cls
+        data = self.conf_data.get(name)
+        return make_response(jsonify(data))
 
 class ConfServer:
-    def __init__(self, name_to_paths_map={}):
+    def __init__(self):
         self.log = logging.getLogger('nano-conf-service')
-
-        self.conf_data = {}
-        from nanorc.argval import validate_conf_name
-        from pathlib import Path
-        for name, path in name_to_paths_map.items():
-            validate_conf_name({}, {}, name)
-            self.conf_data[name] = self.get_json_recursive(Path(path))
-
-
-    def get_json_recursive(self, path):
-        import json, os
-
-        data = {}
-        boot = path/"boot.json"
-        if os.path.isfile(boot):
-            with open(boot,'r') as f:
-                data['boot'] = json.load(f)
-
-        for filename in os.listdir(path):
-            if os.path.isfile(path/filename) and filename[-5:] == ".info":
-                with open(path/filename,'r') as f:
-                    data['config_info'] = json.load(f)
-
-        for filename in os.listdir(path/"data"):
-            with open(path/'data'/filename,'r') as f:
-                app_cmd = filename.replace('.json', '').split('_')
-                app = app_cmd[0]
-                cmd = "_".join(app_cmd[1:])
-
-                if not app in data:
-                    data[app] = {
-                        cmd: json.load(f)
-                    }
-                else:
-                    data[app][cmd]=json.load(f)
-
-        return data
 
     def start_conf_service(self, port):
         from flask import Flask
@@ -87,13 +46,12 @@ class ConfServer:
 
         self.app = Flask('nano-conf-svc')
         self.api = Api(self.app)
-
-        RetrieveConf_withdata = RetrieveConf.set_conf_data(self.conf_data)
-        ListConf_withdata     = ListConf.set_conf_data(self.conf_data)
-
-        self.api.add_resource(RetrieveConf_withdata, "/retrieveLast", methods=['GET'])
-        self.api.add_resource(ListConf_withdata    , "/"    , methods=['GET'])
-        #self.api.add_resource(ListConf_withdata    , "/"            , methods=['GET'])
+        config_data = {}
+        self.api.add_resource(
+            ConfigurationEndpoint, "/configuration",
+            methods = ['GET', 'POST'],
+            resource_class_kwargs = {"config_data":config_data}
+        )
 
         from .utils import FlaskManager
         self.manager = FlaskManager(
@@ -103,6 +61,9 @@ class ConfServer:
         )
 
         self.manager.start()
+
+    def is_ready(self):
+        return self.manager.is_ready()
 
     def terminate(self):
         self.manager.stop()

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -57,7 +57,7 @@ class NanoRC:
             top_cfg=top_cfg,
             console=self.console,
             fsm_conf=fsm_cfg,
-            resolve_hostname = pm.use_sshpm(),
+            process_manager_description = pm,
             port_offset=self.port_offset,
             session = partition_label,
         )
@@ -97,6 +97,9 @@ class NanoRC:
 
         self.topnode = self.cfg.get_tree_structure()
         self.console.print(f"Running on the apparatus [bold red]{self.cfg.apparatus_id}[/bold red]:")
+
+    def quit(self):
+        self.cfg.terminate()
 
     def get_command_sequence(self, command:str):
         seq_cmd = self.topnode.fsm.command_sequences.get(command)

--- a/src/nanorc/pmdesc.py
+++ b/src/nanorc/pmdesc.py
@@ -3,6 +3,7 @@ from .k8spm import K8SProcessManager
 from .sshpm import SSHProcessManager
 from urllib import parse
 
+
 class pm_desc:
     def __init__(self, pm_arg):
         self.arg = pm_arg
@@ -50,7 +51,7 @@ class PMFactory:
         if pm.use_k8spm():
             # Yes, we need the list of connections here
             connections = {}
-            for app, data in self.cfgmgr.data.items():
+            for app, data in self.cfgmgr.conf_data.items():
                 if not isinstance(data, dict): continue
                 if not 'init' in data: continue
                 connections[app] = []

--- a/src/nanorc/tools/nano_conf_svc.py
+++ b/src/nanorc/tools/nano_conf_svc.py
@@ -11,38 +11,13 @@ console = Console()
 def svc(json_dir, name, port):
     from nanorc.confserver import ConfServer
 
-    cs = ConfServer()
-    cs.start_conf_service(port)
-    while not cs.is_ready():
-        console.print("Confservice is not quite ready yet")
-        from time import sleep
-        sleep(0.1)
+    cs = ConfServer(port)
 
     console.print("Confservice is ready!")
 
-    #global conf_data
-    from nanorc.argval import validate_conf_name
-    from pathlib import Path
-    validate_conf_name({}, {}, name)
-    #session['conf_data'][name] = s
-    from nanorc.utils import get_json_recursive
-    from requests import post, get
-    header = {
-        'Accept' : 'application/json',
-        'Content-Type':'application/json'
-    }
+    cs.add_configuration(name, json_dir)
 
-    import json
-    try:
-        r = post(
-            f'http://0.0.0.0:{port}/configuration?name={name}',
-            headers=header,
-            data=json.dumps(get_json_recursive(Path(json_dir)))
-        )
-        console.print(f'Added \'{name}\' content:\n{r.json()}')
-    except Exception as e:
-        console.print(f'Added \'{name}\' insertion failed:\n{str(e)}')
-
+    from requests import get
     try:
         r = get(
             f'http://0.0.0.0:{port}/configuration?name={name}'

--- a/src/nanorc/tools/nano_conf_svc.py
+++ b/src/nanorc/tools/nano_conf_svc.py
@@ -1,119 +1,36 @@
-import logging
 import click
 from rich.console import Console
-from flask_restful import Resource
-from flask import request, abort, make_response, jsonify
+from nanorc.argval import validate_conf_name
 
-conf_data = {}
-log = logging.getLogger('nano-conf-service')
 console = Console()
-
-
-def validate_conf_name(ctx, param, conf_name):
-  import re
-
-  pat = re.compile(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?')
-  ## Nanorc-12334 allowed (with hyphen) This is straight from k8s error message when the partition name isn't right
-  if not re.fullmatch(pat, conf_name):
-    raise click.BadParameter(f'Name {conf_name} should be alpha-numeric-hyphen! Make sure you name has the form [a-z0-9]([-a-z0-9]*[a-z0-9])?')
-  return conf_name
-
-
-def get_json_recursive(path):
-  import json, os
-
-  data = {}
-  boot = path/"boot.json"
-  if os.path.isfile(boot):
-    with open(boot,'r') as f:
-      data['boot'] = json.load(f)
-
-  for filename in os.listdir(path):
-    if os.path.isfile(path/filename) and filename[-5:] == ".info":
-      with open(path/filename,'r') as f:
-        data['config_info'] = json.load(f)
-
-  for filename in os.listdir(path/"data"):
-    with open(path/'data'/filename,'r') as f:
-      app_cmd = filename.replace('.json', '').split('_')
-      app = app_cmd[0]
-      cmd = "_".join(app_cmd[1:])
-
-      if not app in data:
-        data[app] = {
-          cmd: json.load(f)
-        }
-      else:
-        data[app][cmd]=json.load(f)
-
-
-  return data
-
-'''
-Resources for Flask app
-'''
-class RetrieveConf(Resource):
-  def get(self):
-    log.debug(f'GET "RetrieveConf" request with args: {request.args}')
-    name = request.args.get('name')
-
-    if not name:
-      abort(404, description=f'You need to provide a configuration name!')
-
-    log.debug(f"Looking for config {name}")
-
-    if name not in conf_data:
-      abort(404, description=f'Couldn\'t find the configuration \"{name}\", available configurations are {list(conf_data.keys())}')
-
-    import flask
-    return make_response(jsonify(conf_data[name]))
-
-class ListConf(Resource):
-  def get(self):
-    log.debug(f'GET "RetrieveConf" request')
-    return make_response(jsonify(list(conf_data.keys())))
-
-
-
-def start_service(port):
-  from flask import Flask
-  from flask_restful import Api
-  app = Flask('nano-conf-svc')
-  api = Api(app)
-  api.add_resource(RetrieveConf, "/retrieveLast", methods=['GET'])
-  api.add_resource(ListConf    , "/listConf"    , methods=['GET'])
-  app.run (
-    host = '0.0.0.0',
-    port = port,
-    debug = True
-  )
 
 @click.command()
 @click.argument('json_dir', type=click.Path(exists=True), required=True)
 @click.argument('name', type=str, required=True, callback=validate_conf_name)
 @click.option('--port', type=int, default=None, help='Where the port for the service will be')
-@click.option('--verbose', is_flag=True, type=bool, default=False)
-def svc(json_dir, name, port, verbose):
-  if name in conf_data:
-    raise RuntimeError(f'Configuration name \"{name}\" is already in the conf service.')
+def svc(json_dir, name, port):
+    import threading
+    from nanorc.confserver import ConfServer
 
-  from pathlib import Path
+    cs = ConfServer({name: json_dir})
 
-  conf_data[name] = get_json_recursive(Path(json_dir))
-    header = {
-    'Accept' : 'application/json',
-    'Content-Type':'application/json'
-   }
+    thread = threading.Thread(target=cs.start_conf_service, name="conf-server", args = [port])
+    thread.start()
 
-  start_service(port)
+    import signal
+    def signal_handler(sig, frame):
+        print('Finishing the ConfServer')
+        cs.terminate()
+
+    signal.signal(signal.SIGINT, signal_handler)
 
 def main():
-  try:
-    svc()
-  except Exception as e:
-    console.log("[bold red]Exception caught[/bold red]")
-    console.log(e)
-    console.print_exception()
+    try:
+        svc()
+    except Exception as e:
+        console.log("[bold red]Exception caught[/bold red]")
+        console.log(e)
+        console.print_exception()
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/src/nanorc/tools/nano_conf_svc.py
+++ b/src/nanorc/tools/nano_conf_svc.py
@@ -15,7 +15,7 @@ def svc(json_dir, name, port):
 
     console.print("Confservice is ready!")
 
-    cs.add_configuration(name, json_dir)
+    cs.add_configuration_directory(name, json_dir)
 
     from requests import get
     try:

--- a/src/nanorc/tools/nano_conf_svc.py
+++ b/src/nanorc/tools/nano_conf_svc.py
@@ -9,17 +9,60 @@ console = Console()
 @click.argument('name', type=str, required=True, callback=validate_conf_name)
 @click.option('--port', type=int, default=None, help='Where the port for the service will be')
 def svc(json_dir, name, port):
-    import threading
     from nanorc.confserver import ConfServer
 
-    cs = ConfServer({name: json_dir})
+    cs = ConfServer()
+    cs.start_conf_service(port)
+    while not cs.is_ready():
+        console.print("Confservice is not quite ready yet")
+        from time import sleep
+        sleep(0.1)
 
-    thread = threading.Thread(target=cs.start_conf_service, name="conf-server", args = [port])
-    thread.start()
+    console.print("Confservice is ready!")
+
+    #global conf_data
+    from nanorc.argval import validate_conf_name
+    from pathlib import Path
+    validate_conf_name({}, {}, name)
+    #session['conf_data'][name] = s
+    from nanorc.utils import get_json_recursive
+    from requests import post, get
+    header = {
+        'Accept' : 'application/json',
+        'Content-Type':'application/json'
+    }
+
+    import json
+    try:
+        r = post(
+            f'http://0.0.0.0:{port}/configuration?name={name}',
+            headers=header,
+            data=json.dumps(get_json_recursive(Path(json_dir)))
+        )
+        console.print(f'Added \'{name}\' content:\n{r.json()}')
+    except Exception as e:
+        console.print(f'Added \'{name}\' insertion failed:\n{str(e)}')
+
+    try:
+        r = get(
+            f'http://0.0.0.0:{port}/configuration?name={name}'
+        )
+        console.print(f'\'{name}\' content:\n{r.json().keys()}')
+    except Exception as e:
+        console.print(f'Couldn\'t retrieve \'{name}\':\n{str(e)}')
+
+    try:
+        r = get(
+            f'http://0.0.0.0:{port}/configuration'
+        )
+        console.print(f'Store content:\n{r.json()}')
+    except Exception as e:
+        console.print(f'Couldn\'t retrieve store content:\n{str(e)}')
+
 
     import signal
     def signal_handler(sig, frame):
-        print('Finishing the ConfServer')
+        console.print('Finishing the ConfServer')
         cs.terminate()
 
     signal.signal(signal.SIGINT, signal_handler)

--- a/src/nanorc/tools/nano_conf_svc.py
+++ b/src/nanorc/tools/nano_conf_svc.py
@@ -1,0 +1,115 @@
+import logging
+import click
+from rich.console import Console
+from flask_restful import Resource
+from flask import request, abort, make_response, jsonify
+
+conf_data = {}
+log = logging.getLogger('nano-conf-service')
+console = Console()
+
+
+def validate_conf_name(ctx, param, conf_name):
+  import re
+
+  pat = re.compile(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?')
+  ## Nanorc-12334 allowed (with hyphen) This is straight from k8s error message when the partition name isn't right
+  if not re.fullmatch(pat, conf_name):
+    raise click.BadParameter(f'Name {conf_name} should be alpha-numeric-hyphen! Make sure you name has the form [a-z0-9]([-a-z0-9]*[a-z0-9])?')
+  return conf_name
+
+
+def get_json_recursive(path):
+  import json, os
+
+  data = {}
+  boot = path/"boot.json"
+  if os.path.isfile(boot):
+    with open(boot,'r') as f:
+      data['boot'] = json.load(f)
+
+  for filename in os.listdir(path):
+    if os.path.isfile(path/filename) and filename[-5:] == ".info":
+      with open(path/filename,'r') as f:
+        data['config_info'] = json.load(f)
+
+  for filename in os.listdir(path/"data"):
+    with open(path/'data'/filename,'r') as f:
+      app_cmd = filename.replace('.json', '').split('_')
+      app = app_cmd[0]
+      cmd = "_".join(app_cmd[1:])
+
+      if not app in data:
+        data[app] = {
+          cmd: json.load(f)
+        }
+      else:
+        data[app][cmd]=json.load(f)
+
+
+  return data
+
+'''
+Resources for Flask app
+'''
+class RetrieveConf(Resource):
+  def get(self):
+    log.debug(f'GET "RetrieveConf" request with args: {request.args}')
+    name = request.args.get('name')
+
+    if not name:
+      abort(404, description=f'You need to provide a configuration name!')
+
+    log.debug(f"Looking for config {name}")
+
+    if name not in conf_data:
+      abort(404, description=f'Couldn\'t find the configuration \"{name}\", available configurations are {list(conf_data.keys())}')
+
+    import flask
+    return make_response(jsonify(conf_data[name]))
+
+class ListConf(Resource):
+  def get(self):
+    log.debug(f'GET "RetrieveConf" request')
+    return make_response(jsonify(list(conf_data.keys())))
+
+
+
+def start_service(port):
+  from flask import Flask
+  from flask_restful import Api
+  app = Flask('nano-conf-svc')
+  api = Api(app)
+  api.add_resource(RetrieveConf, "/retrieveLast", methods=['GET'])
+  api.add_resource(ListConf    , "/listConf"    , methods=['GET'])
+  app.run (
+    host = '0.0.0.0',
+    port = port,
+    debug = True
+  )
+
+@click.command()
+@click.argument('json_dir', type=click.Path(exists=True), required=True)
+@click.argument('name', type=str, required=True, callback=validate_conf_name)
+@click.option('--port', type=int, default=None, help='Where the port for the service will be')
+@click.option('--verbose', is_flag=True, type=bool, default=False)
+def svc(json_dir, name, port, verbose):
+  if name in conf_data:
+    raise RuntimeError(f'Configuration name \"{name}\" is already in the conf service.')
+
+  from pathlib import Path
+
+  conf_data[name] = get_json_recursive(Path(json_dir))
+
+  start_service(port)
+
+def main():
+  try:
+    svc()
+  except Exception as e:
+    console.log("[bold red]Exception caught[/bold red]")
+    console.log(e)
+    console.print_exception()
+
+if __name__ == '__main__':
+  main()

--- a/src/nanorc/tools/nano_conf_svc.py
+++ b/src/nanorc/tools/nano_conf_svc.py
@@ -100,6 +100,10 @@ def svc(json_dir, name, port, verbose):
   from pathlib import Path
 
   conf_data[name] = get_json_recursive(Path(json_dir))
+    header = {
+    'Accept' : 'application/json',
+    'Content-Type':'application/json'
+   }
 
   start_service(port)
 

--- a/src/nanorc/treebuilder.py
+++ b/src/nanorc/treebuilder.py
@@ -26,7 +26,7 @@ class ConfigManagerCreationFailed(Exception):
     pass
     def __init__(self, node):
         self.node = node
-        super().__init__(f"Failded to build configuration manager for node '{node}'")
+        super().__init__(f"Failed to build configuration manager for node '{node}'")
 
 
 class TreeBuilder:

--- a/src/nanorc/utils.py
+++ b/src/nanorc/utils.py
@@ -168,9 +168,18 @@ def get_json_recursive(path):
             data['boot'] = json.load(f)
 
     for filename in os.listdir(path):
-        if os.path.isfile(path/filename) and filename[-5:] == ".info":
+        if os.path.isfile(path/filename):
+            file_base, _ = os.path.splitext(filename)
             with open(path/filename,'r') as f:
-                data['config_info'] = json.load(f)
+                try:
+                    data[file_base] = json.load(f)
+                except:
+                    print(f'WARNING: ignoring non-json file: {path/filename}')
+        elif os.path.isdir(path/filename):
+            data[filename] = get_json_recursive(path/filename)
+
+    if not os.path.isdir(path/'data'):
+        return data
 
     for filename in os.listdir(path/"data"):
         with open(path/'data'/filename,'r') as f:

--- a/src/nanorc/utils.py
+++ b/src/nanorc/utils.py
@@ -1,6 +1,110 @@
 import threading
 import queue
 import time
+from typing import NoReturn
+from multiprocessing import Process
+from flask import request
+import logging
+
+class FlaskManager(threading.Thread):
+    def __init__(self, name, app, port):
+        threading.Thread.__init__(self)
+        self.log = logging.getLogger(f"{name}-flaskmanager")
+        self.name = name
+        self.app = app
+        self.flask = None
+        self.port = port
+
+        self.ready = False
+        self.ready_lock = threading.Lock()
+
+    def _create_flask(self) -> Process:
+        need_ready = True
+        need_shutdown = True
+
+        for rule in self.app.url_map.iter_rules():
+            if rule.endpoint == "readystatus":
+                need_ready = False
+            if rule.endpoint == "shutdown":
+                need_shutdown = False
+
+
+        def get_ready_status():
+            return "ready"
+
+        # no clue how to do that, so multiprocessing.Process.terminate it will be.
+        # def shutdown():
+        #     func = request.environ.get('werkzeug.server.shutdown')
+        #     if func is None:
+        #         raise RuntimeError('Not running with the Werkzeug Server')
+        #     func()
+
+        if need_ready:
+            self.app.add_url_rule("/readystatus", "get_ready_status", get_ready_status, methods=["GET"])
+        if need_shutdown:
+            pass
+            # self.app.add_url_rule("/shutdown", "get", shutdown, methods=["GET"])
+
+        thread_name = f'{self.name}_thread'
+        flask_srv = Process(target=self.app.run, kwargs={"host": "0.0.0.0", "port": self.port}, name=thread_name)
+        flask_srv.daemon = False
+        flask_srv.start()
+        self.log.info(f'{self.name} Flask lives on PID: {flask_srv.pid}')
+        ## app.is_ready() would be good here, rather than horrible polling inside a try
+        tries=0
+
+        from requests import get
+
+        while True:
+            if tries>20:
+                self.log.error(f'Cannot ping the {self.name}!')
+                self.log.error('This can happen if the web proxy is on at NP04.'+
+                               '\nExit NanoRC and try again after executing:'+
+                               '\nsource ~np04daq/bin/web_proxy.sh -u')
+                raise RuntimeError(f"Cannot create a {self.name}")
+            tries += 1
+            try:
+                resp = get(f"http://0.0.0.0:{self.port}/readystatus")
+                if resp.text == "ready":
+                    break
+            except Exception as e:
+                pass
+            time.sleep(0.5)
+
+        # We don't release that lock before we have received a "ready" from the listener
+        with self.ready_lock:
+            self.ready = True
+
+        return flask_srv
+
+    def stop(self) -> NoReturn:
+        self.flask.terminate()
+        self.flask.join()
+        self.join()
+
+    def is_ready(self):
+        with self.ready_lock:
+            return self.ready
+
+    def _create_and_join_flask(self):
+        with self.ready_lock:
+            self.ready = False
+
+        self.flask = self._create_flask()
+        self.flask.join()
+        with self.ready_lock:
+            self.ready = False
+
+        self.log.info(f'{self.name}-flaskmanager terminated')
+
+    def run(self) -> NoReturn:
+        self._create_and_join_flask()
+
+
+
+
+
+
 
 class Task:
     def __init__(self, function, *args, **kwargs):

--- a/src/nanorc/utils.py
+++ b/src/nanorc/utils.py
@@ -6,6 +6,7 @@ from multiprocessing import Process
 from flask import request
 import logging
 
+
 class FlaskManager(threading.Thread):
     def __init__(self, name, app, port):
         threading.Thread.__init__(self)
@@ -157,6 +158,34 @@ class TaskEnqueuerThread(threading.Thread):
 
             time.sleep(0.1)
 
+def get_json_recursive(path):
+    import json, os
+
+    data = {}
+    boot = path/"boot.json"
+    if os.path.isfile(boot):
+        with open(boot,'r') as f:
+            data['boot'] = json.load(f)
+
+    for filename in os.listdir(path):
+        if os.path.isfile(path/filename) and filename[-5:] == ".info":
+            with open(path/filename,'r') as f:
+                data['config_info'] = json.load(f)
+
+    for filename in os.listdir(path/"data"):
+        with open(path/'data'/filename,'r') as f:
+            app_cmd = filename.replace('.json', '').split('_')
+            app = app_cmd[0]
+            cmd = "_".join(app_cmd[1:])
+
+            if not app in data:
+                data[app] = {
+                    cmd: json.load(f)
+                }
+            else:
+                data[app][cmd]=json.load(f)
+
+    return data
 
 def main():
     class some_object():


### PR DESCRIPTION
With this PR, nanorc serves the configuration over the network rather than relying on a shared file system.
This should work with and without k8s and no matter if the configuration was uploaded to the MongoDB configuration service.

There is also quite a bit of refactoring in `cfgmgr.py`, that code still is... not great.

I suggest testing this the following way:
 - running nanorc with ssh
 - same as above with a partition offset
 - uploading the configuration to MongoDB and running ssh nanorc with `db://config-name` as the name of the configuration
 - same as above with a partition offset
 - running nanorc with k8s
 - same as above with a partition offset
 - uploading the k8s configuration to MongoDB and running k8s nanorc with `db://config-name` as the name of the configuration
 - same as above with a partition offset
 - running 2 DAQ subsystems (with a topjson) using ssh
 - running 2 DAQ subsystems (with a topjson) using k8s
