### PR TITLE
PodSecurity settings and egresses

### DIFF
--- a/src/nanorc/k8spm.py
+++ b/src/nanorc/k8spm.py
@@ -855,15 +855,15 @@ class K8SProcessManager(object):
         self.nanorc_responder = responder_name
 
 
-        # if 'external_services' in boot_info:
-        #     for name, svc in boot_info['external_services'].items():
-        #         info_ip = socket.gethostbyname(svc['host'])
-        #         self.create_egress_endpoint(
-        #             name = name,
-        #             namespace = self.partition,
-        #             ip = info_ip,
-        #             port = svc['port']
-        #         )
+        if 'external_services' in boot_info:
+            for name, svc in boot_info['external_services'].items():
+                info_ip = socket.gethostbyname(svc['host'])
+                self.create_egress_endpoint(
+                    name = name,
+                    namespace = self.partition,
+                    ip = info_ip,
+                    port = svc['port']
+                )
 
 
         with Progress(

--- a/src/nanorc/k8spm.py
+++ b/src/nanorc/k8spm.py
@@ -182,7 +182,7 @@ class K8SProcessManager(object):
             }
         }
 
-        self._core_v1_api.patch_namespace(namespace, body)
+        self._core_v1_api.patch_namespace(namespace, metadata)
 
     # ----
     def delete_namespace(self, namespace: str):

--- a/src/nanorc/k8spm.py
+++ b/src/nanorc/k8spm.py
@@ -161,13 +161,28 @@ class K8SProcessManager(object):
             metadata=client.V1ObjectMeta(name=namespace)
         )
         try:
-            #
             resp = self._core_v1_api.create_namespace(
                 body=ns
             )
         except Exception as e:
             self.log.error(e)
             raise RuntimeError(f"Failed to create namespace \"{namespace}\"") from e
+
+
+        metadata = {
+            "metadata": {
+                "labels": {
+                    "pod-security.kubernetes.io/enforce":"privileged",
+                    "pod-security.kubernetes.io/enforce-version":"latest",
+                    "pod-security.kubernetes.io/warn":"privileged",
+                    "pod-security.kubernetes.io/warn-version":"latest",
+                    "pod-security.kubernetes.io/audit":"privileged",
+                    "pod-security.kubernetes.io/audit-version":"latest"
+                }
+            }
+        }
+
+        self._core_v1_api.patch_namespace(namespace, body)
 
     # ----
     def delete_namespace(self, namespace: str):
@@ -457,7 +472,7 @@ class K8SProcessManager(object):
             )
         )
 
-        #self.log.debug(pod)
+        self.log.debug(pod)
 
         # Creation of the pod in specified namespace
         try:

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -266,7 +266,7 @@ class SubsystemNode(StatefulNode):
             if event.kwargs['pm'].use_k8spm():
                 response_host = self.pm.nanorc_responder
                 proxy = (event.kwargs['pm'].address, event.kwargs['pm'].port)
-                logging.warn(f"respons_host={response_host}, proxy={proxy} ")
+                logging.debug(f"respons_host={response_host}, proxy={proxy} ")
 
             child = ApplicationNode(
                 name=n,

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -266,6 +266,7 @@ class SubsystemNode(StatefulNode):
             if event.kwargs['pm'].use_k8spm():
                 response_host = self.pm.nanorc_responder
                 proxy = (event.kwargs['pm'].address, event.kwargs['pm'].port)
+                logging.warn(f"respons_host={response_host}, proxy={proxy} ")
 
             child = ApplicationNode(
                 name=n,

--- a/tests/k8s_test0.py
+++ b/tests/k8s_test0.py
@@ -151,7 +151,7 @@ def create_daqapp_deployment(api, name, namespace):
     create_deployment(api, daqapp_manifest, name, namespace)
     
 
-def create_nanorc_responder(api, name, namespace):
+def create_egress_endpoint(api, name, namespace):
     # Load template from file
     manifests = load_manifest(path.join('/home/ale/devel/pocket/', 'pocket', 'manifests', 'minidaqapp', 'nanorc_responder.yaml'))
     dep['metadata']['namespace'] = namespace
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     list_pods(core_v1)
 
     create_daqapp_deployment(apps_v1, 'rubu', 'dunedaq')
-    # create_nanorc_responder(apps_v1, 'nanorc', 'dunedaq ')
+    # create_egress_endpoint(apps_v1, 'nanorc', 'dunedaq ')
 
     # # time.sleep(10)
     # while(True):


### PR DESCRIPTION
The PR adds privileged pod security labels to the session namespace, to enable running priviledged containers even if not allowed by cluster security defaults.

```
                "labels": {
                    "pod-security.kubernetes.io/enforce":"privileged",
                    "pod-security.kubernetes.io/enforce-version":"latest",
                    "pod-security.kubernetes.io/warn":"privileged",
                    "pod-security.kubernetes.io/warn-version":"latest",
                    "pod-security.kubernetes.io/audit":"privileged",
                    "pod-security.kubernetes.io/audit-version":"latest"
                }
```

Also, the PR adds the experimental support for custom egress endpoints, through the `boot.conf` `external_services` list

```
'external_services': {
   'monkafka': {
      'host': 'monkafka.cern.ch'
      'port': 30092
   }
}

```


