### PR TITLE
Changing error conditions of apps if not alive or not pingable at conf when running NanoRC

### DIFF
--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -498,6 +498,7 @@ class SubsystemNode(StatefulNode):
 
             failed_ping_count = {app.name:0 for app in appset}
             mode_fail = []
+            failed_ping_thres = 3
             for _ in range(timeout*10):
                 progress.update(timeout_bar, advance=1)
                 if len(appset)==0:
@@ -519,7 +520,6 @@ class SubsystemNode(StatefulNode):
                     is_ping = child_node.sup.commander.ping()
                     if not is_ping:
                         failed_ping_count[child_node.name] += 1
-                        failed_ping_thres = 3
                         if failed_ping_count[child_node.name] > failed_ping_thres:
                             failed.append(child_node.name)
                             mode_fail.append('app not pinging')
@@ -527,7 +527,6 @@ class SubsystemNode(StatefulNode):
                                 command = command,
                             )
                             done += [child_node]
-                            continue
                         continue
                     try:
                         r = child_node.sup.check_response()

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -499,7 +499,6 @@ class SubsystemNode(StatefulNode):
 
             for _ in range(timeout*10):
                 progress.update(timeout_bar, advance=1)
-
                 if len(appset)==0:
                     progress.update(total, completed = n_apps)
                     progress.update(timeout_bar, visible=False)
@@ -507,32 +506,29 @@ class SubsystemNode(StatefulNode):
                 done = []
                 for child_node in appset:
                     if not child_node.included: continue
-                    IsAlive = child_node.sup.desc.proc.is_alive()
-                    if not IsAlive:
-                        failed.append(child_node.name)
-                        self.console.print(f"{child_node.name}, is dead")
+                    is_alive = child_node.sup.desc.proc.is_alive()
+                    if not is_alive:
+                        failed.append('dead')
                         child_node.to_error(
                             command = command,
                         )
                         done += [child_node]
-                        break
-                    IsPing = False
-                    pingattempt=5
-                    for i in range(pingattempt):
-                        IsPing = child_node.sup.commander.ping
-                        if IsPing:
+                        continue
+                    is_ping = False
+                    ping_attempt=5
+                    for i in range(ping_attempt):
+                        is_ping = child_node.sup.commander.ping
+                        if is_ping:
                             break
                         time.sleep(0.1)
-                        self.console.print(f"Trying to ping {child_node.name}, attempt {i+1} of {pingattempt}")
-                    if not IsPing:
-                        failed.append(child_node.name)
-                        self.console.print(f"{child_node.name}, cannot be Pinged")
+                        self.console.print(f"Trying to ping {child_node.name}, attempt {i+1} of {ping_attempt}")
+                    if not is_ping:
+                        failed.append('no_ping')
                         child_node.to_error(
                             command = command,
                         )
                         done += [child_node]
-                        break
-
+                        continue
                     try:
                         r = child_node.sup.check_response()
                     except NoResponse:
@@ -573,7 +569,7 @@ class SubsystemNode(StatefulNode):
                 "error": failed,
             }
             self.to_error(
-                text=f"Children nodes{[r for r in failed]} failed to {command}",
+                text=f"Children nodes{[r for r in failed]} failed to {command} because mode: {failed} ",
                 command=command
             )
         else:

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -520,7 +520,6 @@ class SubsystemNode(StatefulNode):
                     is_ping = child_node.sup.commander.ping()
                     if not is_ping:
                         failed_ping_count += 1
-                        print(f'{child_node.name}:{failed_ping_count}')
                         continue
                     failed_ping_thres = 3
                     if failed_ping_count > failed_ping_thres:

--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -507,9 +507,26 @@ class SubsystemNode(StatefulNode):
                 done = []
                 for child_node in appset:
                     if not child_node.included: continue
-
-                    if not child_node.sup.desc.proc.is_alive() or not child_node.sup.commander.ping():
+                    IsAlive = child_node.sup.desc.proc.is_alive()
+                    if not IsAlive:
                         failed.append(child_node.name)
+                        self.console.print(f"{child_node.name}, is dead")
+                        child_node.to_error(
+                            command = command,
+                        )
+                        done += [child_node]
+                        break
+                    IsPing = False
+                    pingattempt=5
+                    for i in range(pingattempt):
+                        IsPing = child_node.sup.commander.ping
+                        if IsPing:
+                            break
+                        time.sleep(0.1)
+                        self.console.print(f"Trying to ping {child_node.name}, attempt {i+1} of {pingattempt}")
+                    if not IsPing:
+                        failed.append(child_node.name)
+                        self.console.print(f"{child_node.name}, cannot be Pinged")
                         child_node.to_error(
                             command = command,
                         )


### PR DESCRIPTION
Split up check between pod is pingable and pod is alive. If the pod is dead, it fails and sends error, if pod is not pingable it tries again 5 times and then fails. 
Fix for #238 