### PR TITLE
Interrupt start/stop if the run registry insertion failed

### DIFF
--- a/src/nanorc/__main_np04__.py
+++ b/src/nanorc/__main_np04__.py
@@ -247,8 +247,9 @@ def add_run_start_parameters():
         f1 = click.argument('run-type', required=True, type=click.Choice(['TEST', 'PROD']))(function)
         f2 = click.option('--trigger-rate', type=float, default=None, help='Trigger rate in Hz')(f1)
         f3 = click.option('--disable-data-storage/--enable-data-storage', type=bool, default=False, help='Toggle data storage')(f2)
-        f4 = accept_timeout(None)(f3)
-        return click.option('--message', type=str, default="")(f4)
+        f4 = click.option('--ignore-run-registry-insertion-error', type=bool, is_flag=True, default=False, help='Start the run, even if saving the configuration into the run registry fails')(f3)
+        f5 = accept_timeout(None)(f4)
+        return click.option('--message', type=str, default="")(f5)
      # sigh end
     return add_decorator
 

--- a/src/nanorc/__main_timing__.py
+++ b/src/nanorc/__main_timing__.py
@@ -181,7 +181,7 @@ timingcli.add_command(expert_command, 'expert_command')
 @click.pass_obj
 @click.pass_context
 def start(ctx, obj, timeout:int):
-    obj.rc.start(disable_data_storage=True, run_type="TEST", timeout=timeout, trigger_rate=None, message="")
+    obj.rc.start(disable_data_storage=True, run_type="TEST", timeout=timeout, trigger_rate=None, message="", ignore_run_registry_insertion_error=True)
     check_rc(ctx,obj.rc)
     obj.rc.status()
 

--- a/src/nanorc/cfgsvr.py
+++ b/src/nanorc/cfgsvr.py
@@ -202,16 +202,18 @@ class DBConfigSaver:
                                       data=post_data,
                                       auth=(self.API_USER, self.API_PSWD),
                                       timeout=self.timeout)
+                    r.raise_for_status()
+
                 except requests.HTTPError as exc:
-                    error = f"{__name__}: RunRegistryDB: HTTP Error (maybe failed auth, maybe ill-formed post message, ...)"
+                    error = f"{__name__}: RunRegistryDB: HTTP Error: {exc}, {r.text}"
                     self.log.error(error)
                     raise RuntimeError(error) from exc
                 except requests.ConnectionError as exc:
-                    error = f"{__name__}: Connection to {self.API_SOCKET} wasn't successful"
+                    error = f"{__name__}: Connection to {self.API_SOCKET} wasn't successful: {exc}"
                     self.log.error(error)
                     raise RuntimeError(error) from exc
                 except requests.Timeout as exc:
-                    error = f"{__name__}: Connection to {self.API_SOCKET} timed out"
+                    error = f"{__name__}: Connection to {self.API_SOCKET} timed out: {exc}"
                     self.log.error(error)
                     raise RuntimeError(error) from exc
 

--- a/src/nanorc/cfgsvr.py
+++ b/src/nanorc/cfgsvr.py
@@ -231,11 +231,11 @@ class DBConfigSaver:
             self.log.error(error)
             raise RuntimeError(error) from exc
         except requests.ConnectionError as exc:
-            error = f"{__name__}: Connection to {self.API_SOCKET} wasn't successful"
+            error = f"{__name__}: RunRegistryDB: Connection to {self.API_SOCKET} wasn't successful"
             self.log.error(error)
             raise RuntimeError(error) from exc
         except requests.Timeout as exc:
-            error = f"{__name__}: Connection to {self.API_SOCKET} timed out"
+            error = f"{__name__}: RunRegistryDB: Connection to {self.API_SOCKET} timed out"
             self.log.error(error)
             raise RuntimeError(error) from exc
 

--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -233,8 +233,11 @@ def add_run_start_parameters():
         f1 = click.argument('run_num', type=int)(function)
         f2 = click.option('--trigger-rate', type=float, default=None, help='Trigger rate (Hz)')(f1)
         f3 = click.option('--disable-data-storage/--enable-data-storage', type=bool, default=False, help='Toggle data storage')(f2)
-        f4 = accept_timeout(None)(f3)
-        return click.option('--message', type=str, default="")(f4)
+        f4 = click.option(
+            '--ignore-run-registry-insertion-error', type=bool, is_flag=True, default=False,
+            help='Start the run, even if saving the configuration into the run registry fails')(f3)
+        f5 = accept_timeout(None)(f4)
+        return click.option('--message', type=str, default="")(f5)
      # sigh end
     return add_decorator
 

--- a/src/nanorc/common_commands.py
+++ b/src/nanorc/common_commands.py
@@ -40,7 +40,10 @@ def add_run_end_parameters():
     def add_decorator(function):
         f1 = accept_timeout(None)(function)
         f2 = click.option('--force', default=False, is_flag=True)(f1)
-        return click.option('--message', type=str, default="")(f2)
+        f3 = click.option(
+            '--ignore-run-registry-insertion-error', type=bool, is_flag=True, default=False,
+            help='Start the run, even if saving the configuration into the run registry fails')(f2)
+        return click.option('--message', type=str, default="")(f3)
      # sigh end
     return add_decorator
 


### PR DESCRIPTION
Corresponding issue: https://github.com/DUNE-DAQ/ehn1-operations-issues/issues/12

To test (and don't do that too many times, because this creates a run without run registry entry)
 - usual `pip install -e .` of nanorc on this branch.
 - in `nanorc/src/nanorc/conf_data/run_registry.json`, modify the address to be gibberish.
 - try to start a run without the `--ignore-run-registry-insertion-error` flag.
 - stop should fail too without that flag.

