### PR TITLE
Modifications to make use of a new StartParams field (`production_vs_test`)

### DIFF
--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -237,12 +237,13 @@ def add_run_start_parameters():
             '--ignore-run-registry-insertion-error', type=bool, is_flag=True, default=False,
             help='Start the run, even if saving the configuration into the run registry fails')(f3)
         f5 = accept_timeout(None)(f4)
-        return click.option('--message', type=str, default="")(f5)
+        f6 = click.option('--run-type', type=click.Choice(['TEST', 'PROD']))(f5)
+        return click.option('--message', type=str, default="")(f6)
      # sigh end
     return add_decorator
 
 def start_defaults_overwrite(kwargs):
-    kwargs['run_type'] = 'TEST'
+    #kwargs['run_type'] = 'TEST'
     kwargs['path'] = None
     return kwargs
 

--- a/src/nanorc/core.py
+++ b/src/nanorc/core.py
@@ -346,7 +346,8 @@ class NanoRC:
 
         stparam = {
             "run":run,
-            "disable_data_storage":disable_data_storage
+            "disable_data_storage":disable_data_storage,
+            "production_vs_test":run_type
         }
 
         if not trigger_rate is None:


### PR DESCRIPTION
There are two changes in this PR:

- populating a new StartParams field with the value of the nanorc "run-type"  (PROD vs. TEST)
- adding a command-line option to `nanorc` to allow users to specify the "run-type" (so that we can test the downstream logic that depends on the PROD vs. Test choice).  [`nano04rc` already has the ability for the user to specify PROD vs. TEST, but `nanorc` does not yet.

These changes are part of providing a `DUNE.daq_test` field in the file-transfer metadata that we send to offline. It will indicate whether the run was just a test (and therefore the data may not need to be persisted for a long time by the offline).

I will appreciate it if any reviewers of this PR will check that the changes that I've made won't have adverse effects on the various variants of nanorc.

This PR is part of a Deliverable for fddaq-v4.4.0, DUNE-DAQ/daq-deliverables#126, and it depends on a corresponding PR in the `rcif` repo, [PR 10](https://github.com/DUNE-DAQ/rcif/pull/10).