### PR TITLE
10 seconds timeout for k8spm

### DIFF
--- a/src/nanorc/node.py
+++ b/src/nanorc/node.py
@@ -280,7 +280,14 @@ class SubsystemNode(StatefulNode):
                 name=n,
                 console=self.console,
                 log=self.log,
-                sup=AppSupervisor(self.console, d, self.listener, response_host, proxy),
+                sup = AppSupervisor(
+                    console = self.console,
+                    desc = d,
+                    listener = self.listener,
+                    response_host = response_host,
+                    proxy = proxy,
+                    connection_timeout = 10 if event.kwargs['pm'].use_k8spm() else 1,
+                ),
                 parent=self,
                 fsm_conf=self.fsm_conf)
 


### PR DESCRIPTION
To test this. Get the latest nightly, and checkout `production/v4` of `listrev`. Then:

```bash
$ cat >lr.json <<EOL
{
    "boot":{
        "k8s_image": "ghcr.io/dune-daq/alma9-run:develop",
        "process_manager": "k8s",
        "ers_impl":"cern",
        "opmon_impl":"cern",
        "use_connectivity_service": false,
        "start_connectivity_service":false
    }
}
EOL

$ listrev_gen  -c lr.json lr
$ scale_listrev_app --num-apps 100  lr
$ nanorc --pm k8s://np04-srv-016:31000 lr session-name
# ... start the run etc.
```

It also passed the `minimal_system_quick_test` integ tests.