### PR TITLE
bugfix: Added default value for --run-type click option in cli.py

### DIFF
--- a/src/nanorc/cli.py
+++ b/src/nanorc/cli.py
@@ -237,7 +237,7 @@ def add_run_start_parameters():
             '--ignore-run-registry-insertion-error', type=bool, is_flag=True, default=False,
             help='Start the run, even if saving the configuration into the run registry fails')(f3)
         f5 = accept_timeout(None)(f4)
-        f6 = click.option('--run-type', type=click.Choice(['TEST', 'PROD']))(f5)
+        f6 = click.option('--run-type', type=click.Choice(['TEST', 'PROD']), default='TEST')(f5)
         return click.option('--message', type=str, default="")(f6)
      # sigh end
     return add_decorator


### PR DESCRIPTION
When running tests with the latest `nanorc` code on the `production/v4` branch, I noticed complaints about failures in running the "lower" function on an empty object.  I traced this to a lack of a default value in the --run-type  option that I added to `nanorc` in cli.py recently.  The code change in this PR fixes this bug.

Before the change, we can not start runs with `nanorc` without explicitly specifying the --run-type start/start_run parameter.

With this change, a default value of "TEST" is assigned to the run_type and subsequent operations such as "lower" now work.